### PR TITLE
allow instantiation of the base Post_Object type - #67085

### DIFF
--- a/src/Post_Type/Post_Object.php
+++ b/src/Post_Type/Post_Object.php
@@ -22,7 +22,7 @@ use Tribe\Libs\Post_Meta\Meta_Repository;
  * an appropriate Meta_Group, via the `get_meta()` method
  * called with a registered key.
  */
-abstract class Post_Object {
+class Post_Object {
 	const NAME = '';
 
 	/** @var Meta_Map */
@@ -75,7 +75,11 @@ abstract class Post_Object {
 		if ( !$meta_repo ) {
 			$meta_repo = new Meta_Repository();
 		}
-		$post = new static( $post_id, $meta_repo->get( static::NAME ) );
+		$post_type = static::NAME;
+		if ( empty( $post_type ) ) {
+			$post_type = get_post_type( $post_id );
+		}
+		$post = new static( $post_id, $meta_repo->get( $post_type ) );
 		return $post;
 	}
 }


### PR DESCRIPTION
Generally speaking, if you want to work with a object for a post type, you want to get that specific post type's class. E.g., if you have a "Program", you'll call `Program::factory( $post_id )`. That gives you access to both the meta associated with the Program post type, plus any additional utility methods the class might give you.

Sometimes, though, you don't need to know what post type you have. For example, every post type on a site has meta associated with the page header, so they are all connected to the Header meta group.

The front-end template for the header shouldn't have to build a giant `switch` statement to get the correct `Post_Object` subclass for each post type, only to make the same call on each. Instead, it should be able to instantiate the parent `Post_Object` class and make generic `get_meta` calls on it.

```
$post_object = Post_Object::factory( $post_id );
$banner_image = $post_object->get_meta( Header::BANNER_IMAGE );
```
