### PR TITLE
Feature/extend labels coverage

### DIFF
--- a/src/Post_Type/Post_Type_Registration.php
+++ b/src/Post_Type/Post_Type_Registration.php
@@ -38,7 +38,9 @@ class Post_Type_Registration {
 			}
 
 			$args = $config->get_args();
-			$args[ 'labels' ] = wp_parse_args( empty( $args[ 'labels' ] ) ? [] : $args[ 'labels' ], $config->get_labels() );
+			$labels = empty( $args[ 'labels' ] ) ? [] : $args[ 'labels' ];
+			//allow adding more than 3 labels to get_labels
+			$args[ 'labels' ] = wp_parse_args( $labels, $config->get_labels() );
 			register_extended_post_type( $config->post_type(), $args, $config->get_labels() );
 
 


### PR DESCRIPTION
The Post_Type/Config classes use a method called get_labels() this is misleading because the only labels you can set here are singular, plural, slug.
While this covers most cases there are instances when we need to adjust other labels such as all_items. We can do that by adding a labels key to get_args().
What I propose is we feed in the result from get_labels() into the labels key right before we send it to the register_extended_post_type(). 
This keep backward compat intact and gives us full range from the get_labels() function.
