### PR TITLE
Add ability to register ACF fields on Taxonomies as well as Post Types

### DIFF
--- a/src/ACF/ACF_Meta_Group.php
+++ b/src/ACF/ACF_Meta_Group.php
@@ -7,6 +7,13 @@ use Tribe\Libs\Post_Meta\Meta_Group;
 
 abstract class ACF_Meta_Group extends Meta_Group {
 
+	protected $taxonomies;
+
+	public function __construct( $post_types, $taxonomies = [] ) {
+		parent::__construct( $post_types );
+		$this->taxonomies = $taxonomies;
+	}
+
 	public function hook() {
 		add_action( 'acf/init', [ $this, 'register_group' ], 10, 0 );
 	}

--- a/src/ACF/Group.php
+++ b/src/ACF/Group.php
@@ -10,6 +10,8 @@ class Group extends ACF_Configuration implements ACF_Aggregate {
 
 	protected $post_types = [ ];
 
+	protected $taxonomies = [ ];
+
 	public function add_field( Field $field ) {
 		$this->fields[] = $field;
 	}
@@ -30,6 +32,17 @@ class Group extends ACF_Configuration implements ACF_Aggregate {
 				],
 			];
 		}
+
+		foreach ( $this->taxonomies as $taxonomy ) {
+			$attributes['location'][] = [
+				[
+					'param'    => 'taxonomy',
+					'operator' => '==',
+					'value'    => $taxonomy,
+				],
+			];
+		}
+
 		return $attributes;
 	}
 
@@ -41,5 +54,16 @@ class Group extends ACF_Configuration implements ACF_Aggregate {
 	 */
 	public function set_post_types( array $post_types ) {
 		$this->post_types = $post_types;
+	}
+
+	/**
+	 * Set the taxonomy types in which this group will be available
+	 *
+	 * @param array $taxonomies
+	 *
+	 * @return void
+	 */
+	public function set_taxonomies( array $taxonomies ) {
+		$this->taxonomies = $taxonomies;
 	}
 }


### PR DESCRIPTION
I ran into an issue on a recent project where we needed to register some Meta Boxes on Taxonomies vs. just on Post Types. This adds the ability to optionally send a 2nd parameter of an array of Taxonomy slugs when setting up a `ACF_Meta_Group` object. 

It's set up to be as non-impactful as possible - you can ignore it entirely and continue to register `ACF_Meta_Groups` with only Post_Types. I added the parameter to `ACF_Meta_Group` as I'm not sure if abstracting it all the way out to the base `Meta_Group` class makes sense if we ever move away from ACF to another system (which may or may not have Taxonomy meta functionality). I'm definitely willing to consider moving it, however.

Let me know if I'm duplicating a feature which already exists. I couldn't find an existing way to do this without a bit of coding. I know it's perhaps a bit of a fringe case (I don't often need to register metaboxes for Taxonomies Terms), but I think it happens often enough that accommodating for it might not be a bad idea. 