### PR TITLE
handle attachment post type in acf registration

### DIFF
--- a/src/ACF/Group.php
+++ b/src/ACF/Group.php
@@ -22,13 +22,23 @@ class Group extends ACF_Configuration implements ACF_Aggregate {
 		}
 
 		foreach ( $this->post_types as $post_type ) {
-			$attributes[ 'location' ][] = [
-				[
-					'param'    => 'post_type',
-					'operator' => '==',
-					'value'    => $post_type,
-				],
-			];
+			if ( $post_type === 'attachment' ) {
+				$attributes[ 'location' ][] = [
+					[
+						'param'    => 'attachment',
+						'operator' => '==',
+						'value'    => 'all',
+					],
+				];
+			} else {
+				$attributes[ 'location' ][] = [
+					[
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => $post_type,
+					],
+				];
+			}
 		}
 		return $attributes;
 	}


### PR DESCRIPTION
ACF uses a different formula for adding fields to attachment post types vs
all other post types. The ACF\Group can mask that distinction.