### PR TITLE
Add base implementation for get_value() on acf meta

### DIFF
--- a/src/ACF/ACF_Meta_Group.php
+++ b/src/ACF/ACF_Meta_Group.php
@@ -16,6 +16,22 @@ abstract class ACF_Meta_Group extends Meta_Group {
 		acf_add_local_field_group( $config );
 	}
 
+
+	/**
+	 * Base implementation that uses get_field() for all registered keys
+	 *
+	 * If you have calculated/aggregated keys that don't match directly
+	 * to a meta, you'll need to override this method on the child class.
+	 *
+	 * @param int    $post_id
+	 * @param string $key
+	 *
+	 * @return mixed|null
+	 */
+	public function get_value( $post_id, $key ) {
+		return in_array( $key, $this->get_keys(), true ) ? get_field( $key, $post_id ) : null;
+	}
+
 	/**
 	 * @return array The ACF config array for the field group
 	 */


### PR DESCRIPTION
Adds a base implementation of get_value for acf groups that covers the most basic (and most common) case.