### PR TITLE
Add means to get field data reliably

### DIFF
--- a/src/ACF/Field.php
+++ b/src/ACF/Field.php
@@ -6,4 +6,15 @@ namespace Tribe\Libs\ACF;
 
 class Field extends ACF_Configuration {
 	protected $key_prefix = 'field';
+
+	public function get_field( $id, $context = 'post' ) {
+		switch( $context ) {
+			case 'post':
+				return get_post_meta( $id, $this->key, true );
+			case 'user':
+				return get_user_meta( $id, $this->key, true );
+			default:
+				break;
+		}
+	}
 }


### PR DESCRIPTION
The purpose of this PR is because I ran into an issue on flashback where FE theme code could not reliably use the `get_field()` native ACF function. Data would always return `null` regardless. This re-approaches that and uses a more native WordPress approach to meta.

Happy to take it on the chin if this is not a preferred approach, but I do find it odd that we have wrappers in our lib to add fields, but nothing clear to get the data so here's my idea.

This might even belong in `ACF_Configuration`