### PR TITLE
Fixes array sort

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -39,7 +39,7 @@ abstract class Schema {
 	public function do_updates() {
 		$this->clear_option_caches();
 		$updates = $this->get_updates();
-		asort($updates);
+		ksort($updates);
 		try {
 			foreach ( $updates as $version => $callback ) {
 				if ( $this->is_version_in_db_less_than($version) ) {


### PR DESCRIPTION
Using asort() we were sorting on the value instead of the key.
The key is intended to be version number of schema. 
As a result, when running on site that requires multiple schema version callbacks, they may not run in the expected order.