### PR TITLE
Fix class type for Term_Object

### DIFF
--- a/src/Taxonomy/Term_Object.php
+++ b/src/Taxonomy/Term_Object.php
@@ -22,7 +22,7 @@ use Tribe\Libs\Object_Meta\Meta_Repository;
  * an appropriate Meta_Group, via the `get_meta()` method
  * called with a registered key.
  */
-abstract class Term_Object {
+class Term_Object {
 	const NAME = '';
 
 	/** @var Meta_Map */


### PR DESCRIPTION
Term_Object was abstract, which causes an error if you try to instantiate it when you don't know the specific taxo type you're dealing with.