### PR TITLE
Feature/roles

### DIFF
--- a/src/Roles/Capabilities.php
+++ b/src/Roles/Capabilities.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Tribe\Libs\Roles;
+
+/**
+ * Class Capabilities
+ *
+ * @package Tribe\Libs\Roles
+ *
+ * A utililty class for custom capabilities
+ */
+class Capabilities {
+	const VIEW_ADMIN_DASHBOARD = 'tribe_view_admin_dashboard';
+} 

--- a/src/Roles/Dashboard_Restrictor.php
+++ b/src/Roles/Dashboard_Restrictor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tribe\Libs\Roles;
+
+class Dashboard_Restictor {
+
+	/**
+	 * Restricts the admin dashboard from roles without the required capability.
+	 *
+	 * @action admin_init 0 0
+	 * @see \Tribe\Libs\Roles\Roles_Provider::restrict_admin_dashboard
+	 */
+	public function check_user() {
+		if ( ! current_user_can( Capabilities::VIEW_ADMIN_DASHBOARD ) ) {
+			$redirect_url = get_site_url();
+
+			// Provide some context on why the redirect happened
+			$redirect_url = add_query_arg( 'unauthorized', '', $redirect_url );
+
+			wp_redirect( $redirect_url );
+			exit;
+		}
+	}
+
+}

--- a/src/Roles/Login_Redirector.php
+++ b/src/Roles/Login_Redirector.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tribe\Libs\Roles;
+
+use Tribe\Libs\Roles\Role\Role;
+
+use WP_User;
+
+class Login_Redirector {
+
+	private $roles;
+
+	/**
+	 * Login_Redirector constructor.
+	 *
+	 * @param array $roles Array of concrete instances of \Tribe\Libs\Roles\Role\Role
+	 */
+	public function __construct( array $roles ) {
+		$this->roles = $roles;
+	}
+
+	/**
+	 * Maybe overrides the login redirection URL for this Role
+	 *
+	 * @filter login_redirect 10 3
+	 *
+	 * @param $redirect_to
+	 * @param $requested_redirect_to
+	 * @param $user
+	 *
+	 * @return string
+	 * @see \Tribe\Libs\Roles\Roles_Provider::redirect_after_login
+	 */
+	public function redirect_after_login( $redirect_to, $requested_redirect_to, $user ) {
+		// Early bail: no user available
+		if ( ! $user instanceof WP_User ) {
+			return $requested_redirect_to;
+		}
+
+		// Try to find a matching Role for this user
+		/** @var Role $role */
+		foreach ( $this->roles as $role ) {
+			// Early bail: user does have this role
+			if ( ! $user->has_cap( $role->get_slug() ) ) {
+				return $requested_redirect_to;
+			}
+
+			// Early bail: role does not overrides login redirection
+			if ( empty( $role->url_to_redirect_after_login() ) ) {
+				return $requested_redirect_to;
+			} else {
+				return $role->url_to_redirect_after_login();
+			}
+		}
+
+		// Couldn't find any override. Let's just return the default behavior
+		return $requested_redirect_to;
+	}
+
+}

--- a/src/Roles/Role/Administrator.php
+++ b/src/Roles/Role/Administrator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tribe\Libs\Roles\Role;
+
+class Administrator extends Role {
+	/**
+	 * @inheritDoc
+	 */
+	public function get_slug(): string {
+		return 'administrator';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_display_name(): string {
+		return 'Administrator';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_view_admin_dashboard(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_new_capabilities(): array {
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_capabilities_to_remove(): array {
+		return [];
+	}
+}

--- a/src/Roles/Role/Author.php
+++ b/src/Roles/Role/Author.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tribe\Libs\Roles\Role;
+
+class Author extends Role {
+	/**
+	 * @inheritDoc
+	 */
+	public function get_slug(): string {
+		return 'author';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_display_name(): string {
+		return 'Author';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_view_admin_dashboard(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_new_capabilities(): array {
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_capabilities_to_remove(): array {
+		return [];
+	}
+}

--- a/src/Roles/Role/Editor.php
+++ b/src/Roles/Role/Editor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tribe\Libs\Roles\Role;
+
+class Editor extends Role {
+	/**
+	 * @inheritDoc
+	 */
+	public function get_slug(): string {
+		return 'editor';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_display_name(): string {
+		return 'Editor';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_view_admin_dashboard(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_new_capabilities(): array {
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_capabilities_to_remove(): array {
+		return [];
+	}
+}

--- a/src/Roles/Role/Role.php
+++ b/src/Roles/Role/Role.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tribe\Libs\Roles\Role;
+
+use Tribe\Libs\Roles\Capabilities;
+use WP_Role;
+use WP_User;
+
+abstract class Role {
+	/**
+	 * Get the role slug. Example: "super-admin"
+	 *
+	 * @return string
+	 */
+	abstract public function get_slug(): string;
+
+	/**
+	 * Get the role display name. Example: "Super Admin"
+	 *
+	 * @return string
+	 */
+	abstract public function get_display_name(): string;
+
+	/**
+	 * Determines if given Role can access the wp-admin dashboard
+	 *
+	 * @return bool
+	 */
+	abstract public function can_view_admin_dashboard(): bool;
+
+	/**
+	 * Returns an array of new capabilities for this role.
+	 *
+	 * If the role already exists, the existing capabilities
+	 * will be preserved and these will be added to the Role.
+	 *
+	 * @return array
+	 */
+	abstract public function get_new_capabilities(): array;
+
+	/**
+	 * Returns an array of capabilities to be removed for this role.
+	 *
+	 * @return array
+	 */
+	abstract public function get_capabilities_to_remove(): array;
+
+	/**
+	 * Redirects the user to this URL after login.
+	 * If empty, won't redirect.
+	 *
+	 * @return string
+	 */
+	public function url_to_redirect_after_login(): string {
+		return '';
+	}
+
+	/**
+	 * Register roles.
+	 * If Role exists, it will update capabilities.
+	 */
+	final public function register() {
+		$slug = $this->get_slug();
+		$role = get_role( $slug );
+
+		if ( $role instanceof WP_Role ) {
+			$this->update_existing_role( $role );
+		} else {
+			$this->add_new_role();
+		}
+	}
+
+	private function update_existing_role( WP_Role $role ) {
+		foreach ( $this->get_new_capabilities() as $new_capability ) {
+			$role->add_cap( $new_capability );
+		}
+
+		foreach ( $this->get_capabilities_to_remove() as $cap ) {
+			$role->remove_cap( $cap );
+		}
+
+		if ( $this->can_view_admin_dashboard() ) {
+			$role->add_cap( Capabilities::VIEW_ADMIN_DASHBOARD );
+		} else {
+			$role->remove_cap( Capabilities::VIEW_ADMIN_DASHBOARD );
+		}
+	}
+
+	private function add_new_role() {
+		$new_role = add_role( $this->get_slug(), $this->get_display_name(), $this->get_new_capabilities() );
+
+		if ( $new_role instanceof WP_Role ) {
+			foreach ( $this->get_capabilities_to_remove() as $cap ) {
+				$new_role->remove_cap( $cap );
+			}
+			if ( $this->can_view_admin_dashboard() ) {
+				$new_role->add_cap( Capabilities::VIEW_ADMIN_DASHBOARD );
+			} else {
+				$new_role->remove_cap( Capabilities::VIEW_ADMIN_DASHBOARD );
+			}
+		}
+	}
+}

--- a/src/Roles/Role/Subscriber.php
+++ b/src/Roles/Role/Subscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tribe\Libs\Roles\Role;
+
+class Subscriber extends Role {
+	/**
+	 * @inheritDoc
+	 */
+	public function get_slug(): string {
+		return 'subscriber';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_display_name(): string {
+		return 'Subscriber';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can_view_admin_dashboard(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_new_capabilities(): array {
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_capabilities_to_remove(): array {
+		return [];
+	}
+}

--- a/src/Roles/Roles_Provider.php
+++ b/src/Roles/Roles_Provider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tribe\Libs\Roles;
+
+use Pimple\Container;
+use Tribe\Libs\Container\Service_Provider;
+use Tribe\Libs\Roles\Role\Administrator;
+use Tribe\Libs\Roles\Role\Author;
+use Tribe\Libs\Roles\Role\Editor;
+use Tribe\Libs\Roles\Role\Role;
+use Tribe\Libs\Roles\Role\Subscriber;
+use WP_User;
+
+class Roles_Provider extends Service_Provider {
+	const ROLES = 'users.roles';
+
+	public function register( Container $container ) {
+		$container[ self::ROLES ] = function () {
+			return [
+				new Author,
+				new Administrator,
+				new Editor,
+				new Subscriber,
+			];
+		};
+
+		$this->update_roles( $container );
+		$this->hide_topbar( $container );
+		$this->redirect_after_login( $container );
+		$this->restrict_admin_dashboard( $container );
+	}
+
+	private function update_roles( Container $container ) {
+		$container[ Roles_Schema::class ] = function () use ( $container ) {
+			return new Roles_Schema( $container[ self::ROLES ] );
+		};
+
+		add_action( 'admin_init', function () use ( $container ) {
+			if ( $container[ Roles_Schema::class ]->update_required() ) {
+				$container[ Roles_Schema::class ]->do_updates();
+			}
+		}, 0, 0 );
+	}
+
+	private function hide_topbar( Container $container ) {
+		add_filter( 'show_admin_bar', function (): bool {
+			return current_user_can( Capabilities::VIEW_ADMIN_DASHBOARD );
+		} );
+	}
+
+	private function redirect_after_login( Container $container ) {
+		add_filter( 'login_redirect', function ( $redirect_to, $requested_redirect_to, $user ) use ( $container ) {
+			// Early bail: no user available
+			if ( ! $user instanceof WP_User ) {
+				return $requested_redirect_to;
+			}
+
+			// Try to find a matching Role for this user
+			/** @var Role $role */
+			foreach ( $container[ self::ROLES ] as $role ) {
+				// Early bail: user does have this role
+				if ( ! $user->has_cap( $role->get_slug() ) ) {
+					return $requested_redirect_to;
+				}
+
+				// Early bail: role does not overrides login redirection
+				if ( empty( $role->url_to_redirect_after_login() ) ) {
+					return $requested_redirect_to;
+				} else {
+					return $role->url_to_redirect_after_login();
+				}
+			}
+
+			// Couldn't find any override. Let's just return the default behavior
+			return $requested_redirect_to;
+		}, 10, 3 );
+	}
+
+	private function restrict_admin_dashboard( Container $container ) {
+		$container[ Dashboard_Restictor::class ] = function () {
+			return new Dashboard_Restictor;
+		};
+		add_action( 'admin_init', function () use ( $container ) {
+			$container[ Dashboard_Restictor::class ]->check_user();
+		}, 0, 0 );
+	}
+}

--- a/src/Roles/Roles_Provider.php
+++ b/src/Roles/Roles_Provider.php
@@ -64,6 +64,6 @@ class Roles_Provider extends Service_Provider {
 
 		add_action( 'admin_init', function () use ( $container ) {
 			$container[ Dashboard_Restictor::class ]->check_user();
-		}, 0, 0 );
+		}, 1, 0 );
 	}
 }

--- a/src/Roles/Roles_Schema.php
+++ b/src/Roles/Roles_Schema.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tribe\Libs\Roles;
+
+use Tribe\Libs\Schema\Schema;
+use Tribe\Libs\Roles\Role\Role;
+
+class Roles_Schema extends Schema {
+	protected $schema_version = 1;
+	private $roles = [];
+
+	public function __construct( array $roles ) {
+		parent::__construct();
+		foreach ( $roles as $role ) {
+			if ( is_a( $role, Role::class, true ) ) {
+				$this->roles[] = $role;
+			}
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function get_updates() {
+		return [
+			$this->schema_version => function () {
+				/** @var Role $role */
+				foreach ( $this->roles as $role ) {
+					$role->register();
+				};
+			},
+		];
+	}
+}

--- a/src/Roles/Roles_Schema.php
+++ b/src/Roles/Roles_Schema.php
@@ -6,7 +6,11 @@ use Tribe\Libs\Schema\Schema;
 use Tribe\Libs\Roles\Role\Role;
 
 class Roles_Schema extends Schema {
+	/**
+	 * @var int $schema_version Bump this whenever you make changes to Roles
+	 */
 	protected $schema_version = 1;
+
 	private $roles = [];
 
 	public function __construct( array $roles ) {

--- a/src/Roles/composer.json
+++ b/src/Roles/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "moderntribe/square1-roles",
+    "type": "library",
+    "description": "Roles utilities for square one",
+    "license": "GPL-2.0-only",
+    "config": {
+        "vendor-dir": "vendor",
+        "preferred-install": "dist"
+    },
+    "require": {
+        "php": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Tribe\\Libs\\Roles\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
+}


### PR DESCRIPTION
This is meant to help developers to create new Roles or add/remove capabilities to existing ones.

Since Capabilities are persistent and saved on the database, this PR uses the `Schema` class to version Roles updates.

There is a point of discussion on this PR, which is to keep or remove helper functions such as:

```
\Tribe\Libs\Roles\Roles_Provider::hide_topbar
\Tribe\Libs\Roles\Roles_Provider::redirect_after_login
\Tribe\Libs\Roles\Roles_Provider::restrict_admin_dashboard
```

I thought these functions would be generic enough to be added to the package, but at the same time, it feels like having more responsibilities than it would be desirable.