### PR TITLE
Fixes errors with unregistered post type capabilities

### DIFF
--- a/src/Blog_Copier/Blog_Copier_Provider.php
+++ b/src/Blog_Copier/Blog_Copier_Provider.php
@@ -25,10 +25,22 @@ class Blog_Copier_Provider extends Service_Provider {
 	const FILE_COPY_STRATEGY = 'blog_copier.file_copy_strategy';
 
 	public function register( Container $container ) {
+		$this->register_cpt();
 		$this->admin( $container );
 		$this->tasks( $container );
 		$this->manager( $container );
 		$this->file_copy( $container );
+	}
+
+	/**
+	 * Registers a private CPT to store blog data
+	 */
+	protected function register_cpt() {
+		add_action( 'init', function () {
+			register_post_type( Copy_Manager::POST_TYPE, [
+				'public' => false,
+			] );
+		} );
 	}
 
 	/**


### PR DESCRIPTION
Currently the blog copier attempts to add blog details to an unregistered post type. WP no longer allows you to do this without throwing an error. This PR creates a private post type to avoid those errors.