### PR TITLE
refactor subscriber interface to remove container dependency

### DIFF
--- a/src/Blog_Copier/Blog_Copier_Subscriber.php
+++ b/src/Blog_Copier/Blog_Copier_Subscriber.php
@@ -3,60 +3,46 @@ declare( strict_types=1 );
 
 namespace Tribe\Libs\Blog_Copier;
 
-use Psr\Container\ContainerInterface;
 use Tribe\Libs\Blog_Copier\Strategies\File_Copy_Strategy;
-use Tribe\Libs\Container\Subscriber_Interface;
+use Tribe\Libs\Container\Abstract_Subscriber;
 
-class Blog_Copier_Subscriber implements Subscriber_Interface {
-	public function register( ContainerInterface $container ): void {
-		$this->post_type( $container );
-		$this->admin( $container );
-		$this->manager( $container );
-		$this->file_copy( $container );
+class Blog_Copier_Subscriber extends Abstract_Subscriber {
+	public function register(): void {
+		$this->post_type();
+		$this->admin();
+		$this->manager();
+		$this->file_copy();
 	}
 
-	protected function post_type( ContainerInterface $container ): void {
+	protected function post_type(): void {
 		add_action( 'init', function () {
 			Copy_Manager::register_post_type();
 		} );
 	}
 
-	/**
-	 * @param ContainerInterface $container
-	 */
-	protected function admin( ContainerInterface $container ) {
-		add_action( 'network_admin_menu', function () use ( $container ) {
-			$container->get( Network_Admin_Screen::class )->register_screen();
+	protected function admin() {
+		add_action( 'network_admin_menu', function () {
+			$this->container->get( Network_Admin_Screen::class )->register_screen();
 		}, 10, 0 );
-		add_action( 'network_admin_edit_' . Network_Admin_Screen::NAME, function () use ( $container ) {
-			$container->get( Network_Admin_Screen::class )->handle_submission();
+		add_action( 'network_admin_edit_' . Network_Admin_Screen::NAME, function () {
+			$this->container->get( Network_Admin_Screen::class )->handle_submission();
 		}, 10, 0 );
 
 	}
 
-	/**
-	 * @param ContainerInterface $container
-	 *
-	 * @return void
-	 */
-	protected function manager( ContainerInterface $container ) {
-		add_action( 'tribe/project/copy-blog/copy', function ( Copy_Configuration $configuration ) use ( $container ) {
-			$container->get( Copy_Manager::class )->initialize( $configuration );
+	protected function manager() {
+		add_action( 'tribe/project/copy-blog/copy', function ( Copy_Configuration $configuration ) {
+			$this->container->get( Copy_Manager::class )->initialize( $configuration );
 		}, 10, 1 );
-		add_action( Copy_Manager::TASK_COMPLETE_ACTION, function ( $completed_task, $args ) use ( $container ) {
-			$container->get( Copy_Manager::class )->schedule_next_step( $completed_task, $args );
+		add_action( Copy_Manager::TASK_COMPLETE_ACTION, function ( $completed_task, $args ) {
+			$this->container->get( Copy_Manager::class )->schedule_next_step( $completed_task, $args );
 		}, 10, 2 );
 	}
 
 
-	/**
-	 * @param ContainerInterface $container
-	 *
-	 * @return void
-	 */
-	protected function file_copy( ContainerInterface $container ) {
-		add_action( 'tribe/project/copy-blog/copy-files', function ( $src, $dest ) use ( $container ) {
-			$container->get( File_Copy_Strategy::class )->handle_copy( $src, $dest );
+	protected function file_copy() {
+		add_action( 'tribe/project/copy-blog/copy-files', function ( $src, $dest ) {
+			$this->container->get( File_Copy_Strategy::class )->handle_copy( $src, $dest );
 		}, 10, 2 );
 	}
 }

--- a/src/Cache/Cache_Subscriber.php
+++ b/src/Cache/Cache_Subscriber.php
@@ -3,21 +3,20 @@ declare( strict_types=1 );
 
 namespace Tribe\Libs\Cache;
 
-use Psr\Container\ContainerInterface;
-use Tribe\Libs\Container\Subscriber_Interface;
+use Tribe\Libs\Container\Abstract_Subscriber;
 
-class Cache_Subscriber implements Subscriber_Interface {
-	public function register( ContainerInterface $container ): void {
-		$this->purge( $container );
+class Cache_Subscriber extends Abstract_Subscriber {
+	public function register(): void {
+		$this->purge();
 	}
 
-	protected function purge( ContainerInterface $container ): void {
-		add_action( 'init', function () use ( $container ) {
-			$container->get( Purger::class )->maybe_purge_cache();
+	protected function purge(): void {
+		add_action( 'init', function () {
+			$this->container->get( Purger::class )->maybe_purge_cache();
 		}, 9, 0 );
 
-		add_action( 'admin_bar_menu', function ( $admin_bar ) use ( $container ) {
-			$container->get( Purger::class )->add_admin_bar_button( $admin_bar );
+		add_action( 'admin_bar_menu', function ( $admin_bar ) {
+			$this->container->get( Purger::class )->add_admin_bar_button( $admin_bar );
 		}, 100, 1 );
 	}
 

--- a/src/Container/Abstract_Subscriber.php
+++ b/src/Container/Abstract_Subscriber.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types=1 );
+
+namespace Tribe\Libs\Container;
+
+use Psr\Container\ContainerInterface;
+
+abstract class Abstract_Subscriber implements Subscriber_Interface {
+	/**
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * Abstract_Subscriber constructor.
+	 */
+	public function __construct( ContainerInterface $container ) {
+		$this->container = $container;
+	}
+}

--- a/src/Container/Subscriber_Interface.php
+++ b/src/Container/Subscriber_Interface.php
@@ -7,11 +7,9 @@ use Psr\Container\ContainerInterface;
 
 interface Subscriber_Interface {
 	/**
-	 * Register action/filter listeners too hook into WordPress
-	 *
-	 * @param ContainerInterface $container The project's global DI container
+	 * Register action/filter listeners to hook into WordPress
 	 *
 	 * @return void
 	 */
-	public function register( ContainerInterface $container ): void;
+	public function register(): void;
 }

--- a/src/Generators/Generator_Subscriber.php
+++ b/src/Generators/Generator_Subscriber.php
@@ -3,16 +3,15 @@ declare( strict_types=1 );
 
 namespace Tribe\Libs\Generators;
 
-use Psr\Container\ContainerInterface;
-use Tribe\Libs\Container\Subscriber_Interface;
+use Tribe\Libs\Container\Abstract_Subscriber;
 
-class Generator_Subscriber implements Subscriber_Interface {
-	public function register( ContainerInterface $container ): void {
-		add_action( 'init', function () use ( $container ) {
+class Generator_Subscriber extends Abstract_Subscriber {
+	public function register(): void {
+		add_action( 'init', function () {
 			if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 				return;
 			}
-			foreach ( $container->get( Generator_Definer::COMMANDS ) as $command ) {
+			foreach ( $this->container->get( Generator_Definer::COMMANDS ) as $command ) {
 				$command->register();
 			}
 		}, 0, 0 );

--- a/src/Queues/Queues_Subscriber.php
+++ b/src/Queues/Queues_Subscriber.php
@@ -3,46 +3,45 @@ declare( strict_types=1 );
 
 namespace Tribe\Libs\Queues;
 
-use Psr\Container\ContainerInterface;
-use Tribe\Libs\Container\Subscriber_Interface;
+use Tribe\Libs\Container\Abstract_Subscriber;
 use Tribe\Libs\Queues\CLI\Add_Tasks;
 use Tribe\Libs\Queues\CLI\Cleanup;
 use Tribe\Libs\Queues\CLI\List_Queues;
 use Tribe\Libs\Queues\CLI\Process;
 use Tribe\Libs\Queues\Contracts\Backend;
 
-class Queues_Subscriber implements Subscriber_Interface {
-	public function register( ContainerInterface $container ): void {
-		$this->cli( $container );
-		$this->cron( $container );
+class Queues_Subscriber extends Abstract_Subscriber {
+	public function register(): void {
+		$this->cli();
+		$this->cron();
 	}
 
-	protected function cli( ContainerInterface $container ): void {
-		add_action( 'init', function () use ( $container ) {
+	protected function cli(): void {
+		add_action( 'init', function () {
 			if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 				return;
 			}
 
-			$container->get( List_Queues::class )->register();
-			$container->get( Cleanup::class )->register();
-			$container->get( Process::class )->register();
-			$container->get( Add_Tasks::class )->register();
+			$this->container->get( List_Queues::class )->register();
+			$this->container->get( Cleanup::class )->register();
+			$this->container->get( Process::class )->register();
+			$this->container->get( Add_Tasks::class )->register();
 		}, 0, 0 );
 	}
 
-	protected function cron( ContainerInterface $container ): void {
+	protected function cron(): void {
 		if ( ! defined( 'DISABLE_WP_CRON' ) || false === DISABLE_WP_CRON ) {
-			add_filter( 'cron_schedules', function ( $schedules ) use ( $container ) {
-				$container->get( Cron::class )->add_interval( $schedules );
+			add_filter( 'cron_schedules', function ( $schedules ) {
+				$this->container->get( Cron::class )->add_interval( $schedules );
 			}, 10, 1 );
 
-			add_action( 'admin_init', function () use ( $container ) {
-				$container->get( Cron::class )->schedule_cron();
+			add_action( 'admin_init', function () {
+				$this->container->get( Cron::class )->schedule_cron();
 			}, 10, 0 );
 
-			add_action( Cron::CRON_ACTION, function () use ( $container ) {
-				foreach ( $container->get( Queue_Collection::class )->queues() as $queue ) {
-					$container->get( Cron::class )->process_queues( $queue );
+			add_action( Cron::CRON_ACTION, function () {
+				foreach ( $this->container->get( Queue_Collection::class )->queues() as $queue ) {
+					$this->container->get( Cron::class )->process_queues( $queue );
 				}
 			}, 10, 0 );
 		}

--- a/src/Queues_Mysql/Mysql_Backend_Subscriber.php
+++ b/src/Queues_Mysql/Mysql_Backend_Subscriber.php
@@ -3,26 +3,22 @@ declare( strict_types=1 );
 
 namespace Tribe\Libs\Queues_Mysql;
 
-use Psr\Container\ContainerInterface;
-use Tribe\Libs\Container\Subscriber_Interface;
+use Tribe\Libs\Container\Abstract_Subscriber;
 use Tribe\Libs\Queues_Mysql\Backends\MySQL;
 use Tribe\Libs\Queues_Mysql\CLI\MySQL_Table;
 
-class Mysql_Backend_Subscriber implements Subscriber_Interface {
-	public function register( ContainerInterface $container ): void {
-		$this->backend( $container );
-		$this->cli( $container );
+class Mysql_Backend_Subscriber extends Abstract_Subscriber {
+	public function register(): void {
+		$this->backend();
+		$this->cli();
 	}
 
 	/**
 	 * Register the backend
-	 *
-	 * @param ContainerInterface $container
-	 *
 	 */
-	protected function backend( ContainerInterface $container ) {
-		add_action( 'tribe/project/queues/mysql/init_table', function () use ( $container ) {
-			$container->get( MySQL::class )->initialize_table();
+	protected function backend() {
+		add_action( 'tribe/project/queues/mysql/init_table', function () {
+			$this->container->get( MySQL::class )->initialize_table();
 		}, 10, 0 );
 
 		add_action( 'admin_init', function () {
@@ -32,12 +28,12 @@ class Mysql_Backend_Subscriber implements Subscriber_Interface {
 		}, 0, 0 );
 	}
 
-	protected function cli( ContainerInterface $container ) {
-		add_action( 'init', function () use ( $container ) {
+	protected function cli() {
+		add_action( 'init', function () {
 			if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 				return;
 			}
-			$container->get( MySQL_Table::class )->register();
+			$this->container->get( MySQL_Table::class )->register();
 		}, 0, 0 );
 	}
 }


### PR DESCRIPTION
The use of a container is an implementation detail and should not be required to implement the subscriber interface.

This implementation detail has moved to the constructor of a new `Abstract_Subscriber`. Methods in the subscriber can reference `$this->container` instead of passing the container to all methods.

Props to @Luc45 for talking this through with me