### PR TITLE
migrate object meta subscriber to tribe-libs

### DIFF
--- a/src/Blog_Copier/Blog_Copier_Definer.php
+++ b/src/Blog_Copier/Blog_Copier_Definer.php
@@ -19,7 +19,7 @@ use Tribe\Libs\Container\Definer_Interface;
 use Tribe\Libs\Queues\Contracts\Queue;
 
 class Blog_Copier_Definer implements Definer_Interface {
-	public const TASK_CHAIN = 'blog_copier.task_chain';
+	public const TASK_CHAIN = 'libs.blog_copier.task_chain';
 
 	public function define(): array {
 		return [

--- a/src/CLI/CLI_Definer.php
+++ b/src/CLI/CLI_Definer.php
@@ -7,7 +7,7 @@ use DI;
 use Tribe\Libs\Container\Definer_Interface;
 
 class CLI_Definer implements Definer_Interface {
-	public const COMMANDS = 'cli.commands';
+	public const COMMANDS = 'libs.cli.commands';
 
 	public function define(): array {
 		return [

--- a/src/Generators/Generator_Definer.php
+++ b/src/Generators/Generator_Definer.php
@@ -9,7 +9,7 @@ use Tribe\Libs\CLI\CLI_Definer;
 use Tribe\Libs\Container\Definer_Interface;
 
 class Generator_Definer implements Definer_Interface {
-	public const PATH = 'generator.path';
+	public const PATH = 'libs.generator.path';
 
 	public function define(): array {
 		return [

--- a/src/Object_Meta/Object_Meta_Definer.php
+++ b/src/Object_Meta/Object_Meta_Definer.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types=1 );
+
+namespace Tribe\Libs\Object_Meta;
+
+use DI;
+use Tribe\Libs\Container\Definer_Interface;
+
+class Object_Meta_Definer implements Definer_Interface {
+	public const GROUPS = 'libs.meta.groups';
+
+	public function define(): array {
+		return [
+			/**
+			 * The array of groups that will be registered with the Meta Repository.
+			 * Add more in other Definers using Object_Meta_Definer::GROUPS => DI\add( [ ... ] ).
+			 *
+			 * Groups should extend \Tribe\Libs\Object_Meta\Meta_Group
+			 */
+			self::GROUPS => DI\add( [] ),
+
+			Meta_Repository::class => DI\create()
+				->constructor( DI\get( self::GROUPS ) ),
+		];
+	}
+}

--- a/src/Object_Meta/Object_Meta_Subscriber.php
+++ b/src/Object_Meta/Object_Meta_Subscriber.php
@@ -1,0 +1,21 @@
+<?php
+declare( strict_types=1 );
+
+namespace Tribe\Libs\Object_Meta;
+
+use Tribe\Libs\Object_Meta\Meta_Repository;
+use Tribe\Libs\Container\Abstract_Subscriber;
+
+class Object_Meta_Subscriber extends Abstract_Subscriber {
+	public function register(): void {
+		add_filter( Meta_Repository::GET_REPO_FILTER, function( $repo ) {
+			return $this->container->get( Meta_Repository::class )->filter_global_instance( $repo );
+		}, 10, 1 );
+
+		add_action( 'acf/init', function () {
+			foreach ( $this->container->get( Object_Meta_Definer::GROUPS ) as $group ) {
+				$group->register_group();
+			}
+		}, 10, 0 );
+	}
+}

--- a/src/Object_Meta/README.md
+++ b/src/Object_Meta/README.md
@@ -1,0 +1,101 @@
+# Tribe Libs Object Meta
+
+## Adding Meta Groups
+
+### Create the `Meta_Group`
+
+```php
+<?php
+
+namespace Tribe\Example\Object_Meta;
+
+use Tribe\Libs\ACF;
+
+class Example extends ACF\ACF_Meta_Group {
+
+	public const NAME = 'example_meta';
+
+	public const ONE = 'example_object_meta_one';
+	public const TWO = 'example_object_meta_two';
+
+	public function get_keys() {
+		return [
+			self::ONE,
+			self::TWO,
+		];
+	}
+
+	public function get_group_config() {
+		$group = new ACF\Group( self::NAME, $this->object_types );
+		$group->set( 'title', __( 'Example Object Meta', 'tribe' ) );
+
+		$group->add_field( $this->get_field_one() );
+		$group->add_field( $this->get_field_two() );
+
+		return $group->get_attributes();
+	}
+
+	private function get_field_one() {
+		$field = new ACF\Field( self::NAME . '_' . self::ONE );
+		$field->set_attributes( [
+			'label' => __( 'Example Object Meta #1', 'tribe' ),
+			'name'  => self::ONE,
+			'type'  => 'text',
+		] );
+
+		return $field;
+	}
+
+	private function get_field_two() {
+		$field = new ACF\Field( self::NAME . '_' . self::TWO );
+		$field->set_attributes( [
+			'label' => __( 'Example Object Meta #2', 'tribe' ),
+			'name'  => self::TWO,
+			'type'  => 'text',
+		] );
+
+		return $field;
+	}
+
+}
+```
+
+### Register in the Definer
+
+```php
+<?php
+declare( strict_types=1 );
+
+namespace Tribe\Example\Object_Meta;
+
+use DI;
+use Psr\Container\ContainerInterface;
+use Tribe\Libs\Container\Definer_Interface;
+use Tribe\Example\Settings;
+
+class Object_Meta_Definer implements Definer_Interface {
+	public const GROUPS = 'meta.groups';
+
+	public function define(): array {
+		return [
+			\Tribe\Libs\Object_Meta\Object_Meta_Definer::GROUPS => DI\add( [
+				DI\get( Example::class ),
+			] ),
+
+			Example::class => static function ( ContainerInterface $container ) {
+				return new Example( [ // use one or more of the following options
+					// can be added to post types
+					'post_types'     => [ 'page', 'post' ],
+					// or can be added to taxonomies
+					'taxonomies'     => [ 'category' ],
+					// or can be added to settings screens
+					'settings_pages' => [ $container->get( Settings\General::class )->get_slug() ],
+					// or can be added to user profiles
+					'users'          => true,
+				] );
+			},
+		];
+	}
+}
+
+```

--- a/src/Object_Meta/composer.json
+++ b/src/Object_Meta/composer.json
@@ -8,7 +8,8 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.0",
+        "moderntribe/square1-container": "^2.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Required_Page/README.md
+++ b/src/Required_Page/README.md
@@ -53,3 +53,9 @@ class Content_Definer implements Definer_Interface {
 	}
 }
 ```
+
+The page will now be automatically created. The ID of the page can be found with:
+
+```php
+get_field( Contact_Page::NAME, 'option' );
+```

--- a/src/Required_Page/Required_Page_Definer.php
+++ b/src/Required_Page/Required_Page_Definer.php
@@ -6,7 +6,7 @@ namespace Tribe\Libs\Required_Page;
 use Tribe\Libs\Container\Definer_Interface;
 
 class Required_Page_Definer implements Definer_Interface {
-	public const PAGES = 'required_page.pages';
+	public const PAGES = 'libs.required_page.pages';
 
 	public function define(): array {
 		return [

--- a/src/Whoops/README.md
+++ b/src/Whoops/README.md
@@ -1,0 +1,9 @@
+# Whoops - Better PHP Error Messages
+
+In Local Environments (and local environments only), you can enable [Whoops Error Messaging](http://filp.github.io/whoops/).
+
+Whoops provides a cleaner, more helpful interface for viewing errors when they happen,
+including a clear callstack, server details at the time of the error, preview of the code
+that errored, and all sorts of other goodies.
+
+To enable Whoops, simply add `define( 'WHOOPS_ENABLE', true );` to your local-config.php.


### PR DESCRIPTION
Projects will register their meta groups with the Tribe Libs object meta definer.

```
\Tribe\Libs\Object_Meta\Object_Meta_Definer::GROUPS => DI\add( [
	DI\get( Example::class ),
] ),
```