### PR TITLE
Fix bug in Queues Cron in the 2.0.0 branch

### DIFF
--- a/src/Queues/Cron.php
+++ b/src/Queues/Cron.php
@@ -1,32 +1,46 @@
 <?php
 
-
 namespace Tribe\Libs\Queues;
 
-
-use Tribe\Libs\Queues\Contracts\Queue;
+use Exception;
 use Tribe\Libs\Queues\Contracts\Task;
+use Tribe\Libs\Queues\Contracts\Queue;
 
+/**
+ * Process queues via the WordPress cron
+ *
+ * @package Tribe\Libs\Queues
+ */
 class Cron {
+
 	const CRON_ACTION = 'tribe_queue_cron';
 	const FREQUENCY   = 'tribe_queue_frequency';
 
-	private $frequency_in_seconds = 60;
-	private $timelimit_in_seconds = 15;
+	private $frequency_in_seconds;
+	private $timelimit_in_seconds;
 
-	public function __construct( $frequency = 60, $timelimit = 15 ) {
+	/**
+	 * Cron constructor.
+	 *
+	 * @param  int  $frequency
+	 * @param  int  $timelimit
+	 */
+	public function __construct( int $frequency = 60, int $timelimit = 15 ) {
 		$this->frequency_in_seconds = $frequency;
 		$this->timelimit_in_seconds = $timelimit;
 	}
 
 	/**
-	 * @return void
+	 * Process a Queue's tasks.
+	 *
+	 * @param  \Tribe\Libs\Queues\Contracts\Queue  $queue
+	 *
 	 * @action self::CRON_ACTION
+	 *
+	 * @return void
 	 */
 	public function process_queues( Queue $queue ) {
 		$end_time = time() + $this->timelimit_in_seconds;
-
-		$queue->cleanup();
 
 		while ( time() < $end_time ) {
 
@@ -36,7 +50,7 @@ class Cron {
 
 			try {
 				$job = $queue->reserve();
-			} catch ( \Exception $e ) {
+			} catch ( Exception $e ) {
 				return;
 			}
 
@@ -61,8 +75,11 @@ class Cron {
 	}
 
 	/**
-	 * @return void
+	 * Schedule a cron job.
+	 *
 	 * @action admin_init
+	 *
+	 * @return void
 	 */
 	public function schedule_cron() {
 		if ( ! wp_next_scheduled( self::CRON_ACTION ) ) {
@@ -71,12 +88,15 @@ class Cron {
 	}
 
 	/**
-	 * @param array $cron_schedules
+	 * Filter existing WordPress cron schedules.
+	 *
+	 * @param  array  $cron_schedules
 	 *
 	 * @return array
+	 *
 	 * @filter cron_schedules
 	 */
-	public function add_interval( $cron_schedules ) {
+	public function add_interval( array $cron_schedules = [] ): array {
 		$cron_schedules[ self::FREQUENCY ] = [
 			'interval' => $this->frequency_in_seconds,
 			'display'  => __( 'Queue Cron Schedule', 'tribe' ),
@@ -84,4 +104,16 @@ class Cron {
 
 		return $cron_schedules;
 	}
+
+	/**
+	 * Remove completed and timed out tasks from the queue after a certain ttl.
+	 *
+	 * @param  \Tribe\Libs\Queues\Contracts\Queue  $queue
+	 *
+	 * @return void
+	 */
+	public function cleanup( Queue $queue ) {
+		$queue->cleanup();
+	}
+
 }


### PR DESCRIPTION
This fixes a bug where Queues run via the cron strategy are never actually run because their `run_after` and priority keep getting bumped before they are processed via the cleanup functionality.

This is for users using the 2.x.x Pimple Container versions of tribe-libs. Users should ensure their project's `composer.json` reference the `"~2.1.*"` tag for `tribe-libs` and any of the `square1*` many-repos.