### PR TITLE
Feature/add customizable timeout to queue process command

### DIFF
--- a/src/Queues/CLI/Process.php
+++ b/src/Queues/CLI/Process.php
@@ -41,6 +41,12 @@ class Process extends Command {
 				'optional'    => false,
 				'description' => __( 'The name of the Queue.', 'tribe' ),
 			],
+			[
+				'type'        => 'positional',
+				'name'        => 'timelimit',
+				'optional'    => true,
+				'description' => __( 'The max process execution.', 'tribe' ),
+			],
 		];
 	}
 

--- a/src/Queues/CLI/Process.php
+++ b/src/Queues/CLI/Process.php
@@ -57,6 +57,11 @@ class Process extends Command {
 
 		$queue_name = $args[0];
 
+		// Override the timeout
+		if ( isset( $args[0] ) && is_int( $args[0] ) ) {
+			$this->timelimit = $args[0];
+		}
+
 		if ( ! array_key_exists( $queue_name, $this->queues->queues() ) ) {
 			\WP_CLI::error( __( "That queue name doesn't appear to be valid.", 'tribe' ) );
 		}

--- a/src/Queues/CLI/Process.php
+++ b/src/Queues/CLI/Process.php
@@ -18,7 +18,7 @@ class Process extends Command {
 	 *          the process will run until it meets a fatal error
 	 *          (e.g., out of memory).
 	 */
-	private $timelimit = 300;
+	protected $timelimit = 300;
 
 	public function __construct( Queue_Collection $queue_collection ) {
 		$this->queues = $queue_collection;

--- a/src/Queues/README.md
+++ b/src/Queues/README.md
@@ -8,7 +8,7 @@ time consuming, or network-dependent tasks.
 While it is possible (and in rare cases appropriate) to have multiple queues, most often
 a project will use a single default queue. Using the DI container, your class constructor
 should receive a `\Tribe\Libs\Queues\Contracts\Queue`. Autowiring should take care of the
-reset to give you an instance of the appropriate queue class with the configured backend.
+rest to give you an instance of the appropriate queue class with the configured backend.
 
 ```php
 class Example_Class {


### PR DESCRIPTION
Currently the timelimit (command max execution time) is fixed at 300 seconds. The value is a private property which means extending this class will still not allow adding a param to override the property.

This PR adds an optional parameter to specify max timelimit other than the default of 300. 