### PR TITLE
Queues: Make Task instances with the container

### DIFF
--- a/src/Queues/CLI/Process.php
+++ b/src/Queues/CLI/Process.php
@@ -2,9 +2,13 @@
 
 namespace Tribe\Libs\Queues\CLI;
 
+use DI;
+use Exception;
+use Throwable;
 use Tribe\Libs\CLI\Command;
 use Tribe\Libs\Queues\Contracts\Task;
 use Tribe\Libs\Queues\Queue_Collection;
+use WP_CLI;
 
 class Process extends Command {
 
@@ -14,14 +18,20 @@ class Process extends Command {
 	protected $queues;
 
 	/**
+	 * @var \DI\FactoryInterface
+	 */
+	protected $container;
+
+	/**
 	 * @var int How long the process should run, in seconds. If 0,
 	 *          the process will run until it meets a fatal error
 	 *          (e.g., out of memory).
 	 */
 	private $timelimit = 300;
 
-	public function __construct( Queue_Collection $queue_collection ) {
-		$this->queues = $queue_collection;
+	public function __construct( Queue_Collection $queue_collection, DI\FactoryInterface $container ) {
+		$this->queues    = $queue_collection;
+		$this->container = $container;
 		parent::__construct();
 	}
 
@@ -46,19 +56,19 @@ class Process extends Command {
 
 	public function run_command( $args, $assoc_args ) {
 		if ( ! isset( $args[0] ) ) {
-			\WP_CLI::error( __( 'You must specify which queue you wish to process.', 'tribe' ) );
+			WP_CLI::error( __( 'You must specify which queue you wish to process.', 'tribe' ) );
 		}
 
 		$queue_name = $args[0];
 
 		if ( ! array_key_exists( $queue_name, $this->queues->queues() ) ) {
-			\WP_CLI::error( __( "That queue name doesn't appear to be valid.", 'tribe' ) );
+			WP_CLI::error( __( "That queue name doesn't appear to be valid.", 'tribe' ) );
 		}
 
 		try {
 			$queue = $this->queues->get( $queue_name );
-		} catch ( \Exception $e ) {
-			\WP_CLI::error( $e->getMessage() );
+		} catch ( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
 		}
 
 		$endtime = time() + $this->timelimit;
@@ -68,36 +78,37 @@ class Process extends Command {
 
 			// If the queue is empty, sleep on it and then clear it again.
 			if ( ! $queue->count() ) {
-				\WP_CLI::debug( 'Queue is empty. Sleeping...' );
+				WP_CLI::debug( __( 'Queue is empty. Sleeping...', 'tribe' ) );
 				sleep( 1 );
 				continue;
 			}
 
 			try {
 				$job = $queue->reserve();
-			} catch ( \Exception $e ) {
-				\WP_CLI::debug( 'Unable to reserve task from queue. Sleeping...' );
+			} catch ( Exception $e ) {
+				WP_CLI::debug( __( 'Unable to reserve task from queue. Sleeping...', 'tribe' ) );
 				sleep( 1 );
 				continue;
 			}
 
 			$task_class = $job->get_task_handler();
 
-			if ( ! class_exists( $task_class ) ) {
-				\WP_CLI::debug( sprintf( 'Class %s does not exist.', $task_class ) );
+			try {
+				/** @var Task $task */
+				$task = $this->container->make( $task_class );
+			} catch ( Throwable $e ) {
+				WP_CLI::debug( sprintf( __( 'Unable to create task instance for class "%s". Error: %s', 'tribe' ), $task_class, $e->getMessage() ) );
 				$queue->nack( $job->get_job_id() );
+
 				return;
 			}
 
-			/** @var Task $task */
-			$task = new $task_class();
-
 			if ( $task->handle( $job->get_args() ) ) {
 				// Acknowledge.
-				\WP_CLI::debug( sprintf( 'ACK: %s (%s)', $job->get_job_id(), $task_class ) );
+				WP_CLI::debug( sprintf( 'ACK: %s (%s)', $job->get_job_id(), $task_class ) );
 				$queue->ack( $job->get_job_id() );
 			} else {
-				\WP_CLI::debug( sprintf( 'NACK: %s (%s)', $job->get_job_id(), $task_class ) );
+				WP_CLI::debug( sprintf( 'NACK: %s (%s)', $job->get_job_id(), $task_class ) );
 				$queue->nack( $job->get_job_id() );
 			}
 		}

--- a/src/Queues/README.md
+++ b/src/Queues/README.md
@@ -24,16 +24,104 @@ class Example_Class {
 If you are putting things into queue, it is very likely you will need to create a custom task handler.
 To create a Task class implement `Tribe\Project\Queues\Contracts\Task`.
 
-The method `handle()` is required and must return `true` on success (the task is marked as complete
+The `handle( array $args )` method is required and must return `true` on success (the task is marked as complete
 and removed from the queue), `false` on failure (the task is added back into the queue to try again).
+
+The task handler instance is run in isolation, but still supports auto wiring and dependency injection.
+
+Example Task:
+
+```php
+
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Queues\Tasks;
+
+use Tribe\Libs\Queues\Contracts\Task;
+use Tribe\Project\Posts\Post_Fetcher;
+
+/**
+ * An example of Queue Task using dependency injection
+ */
+class Cache_Slow_Query implements Task {
+
+	public const OPTION = 'tribe_latest_post_cache';
+
+	/**
+	 * Example dependency injection: This object will be
+	 * the service responsible for handling complex logic
+	 * for this task. Moving the logic to a service object
+	 * allows that functionality to be shared outside
+	 * this task in case something else needs to consume
+	 * it.
+	 */
+	private Post_Fetcher $post_fetcher;
+
+	/**
+	 * @param \Tribe\Project\Posts\Post_Fetcher $post_fetcher This is a concrete class. PHP-DI knows to automatically
+	 *                                                        inject the instance without any needed configuration.
+	 */
+	public function __construct( Post_Fetcher $post_fetcher ) {
+		$this->post_fetcher = $post_fetcher;
+	}
+
+	/**
+	 * @param array $args This variable populated with the dynamic data you set
+	 *                    when the Queue Task is dispatched.
+	 *
+	 * @example          $queue->dispatch( Tribe\Project\Queues\Tasks\Cache_Slow_Query::class, [ 'my_custom_post_type' ] );
+	 *
+	 * @return bool
+	 */
+	public function handle( array $args ): bool {
+		// Create the $post_type variable via unpacking of $args[0]
+		[ $post_type ] = $args;
+
+		/**
+		 * Fetch the posts from some very long and intensive query.
+		 *
+		 * @var \WP_Query $query
+		 */
+		$query = $this->post_fetcher->get_latest_posts( $post_type );
+
+		/*
+		 * There are no posts, so return true to avoid placing this back in the queue to run
+		 * again until posts are found.
+		 *
+		 * In this scenario, we'd rather just check that the next time this task is dispatched
+		 * to the queue.
+		 */
+		if ( empty( $query->posts ) ) {
+			return true;
+		}
+
+		/*
+		 * If for some reason our option update doesn't work, it'll automatically be placed back in the
+		 * queue to try again.
+		 *
+		 * Some other service will query this option to display the posts instead of running the
+		 * massive query above in real time.
+		 */
+		return update_option( self::OPTION, $query->posts, false );
+	}
+
+}
+
+```
 
 ## Adding a task to the queue
 
 You dispatch tasks to the queue to indicate which class handles the task, and the arguments array to pass
-to the `handle()` method.
+to the `handle()` method. For example, ff your tasks requires a Post ID to complete its process, 
+you can populate the `$args` variable during dispatch and the static value will be saved in the Queue
+for when the task is processed. 
 
 ```php
-$queue->dispatch( Task::class, $args );
+add_action( 'save_post', function ( $post_id ): void {
+	$queue->dispatch( My_Task::class, [
+		(int) $post_id,
+	] );
+}, 10, 1 );
 ```
 
 


### PR DESCRIPTION
This update allows Queue Task implementations to use dependency injection/auto wiring, greatly simplifying the arguments you'd need to create when dispatching a task to the queue.

Imagine that the [Email Task](https://github.com/moderntribe/tribe-libs/blob/master/src/Queues/Tasks/Email.php#L17) could be updated to instead take an object in the constructor that contained a bunch of default/shared configuration or if you just need other dependencies that the container resolve on its own, we can now do that.

Also, I need this functionality for the Explore Navigation plugin :)