### PR TITLE
Feature/queue timeout option

### DIFF
--- a/src/Queues/CLI/Process.php
+++ b/src/Queues/CLI/Process.php
@@ -10,7 +10,14 @@ use Tribe\Libs\Queues\Contracts\Task;
 use Tribe\Libs\Queues\Queue_Collection;
 use WP_CLI;
 
+use function WP_CLI\Utils\get_flag_value;
+
 class Process extends Command {
+
+	public const ARG_QUEUE     = 'queue';
+	public const ARG_TIMELIMIT = 'timelimit';
+
+	public const DEFAULT_TIMELIMIT = 300;
 
 	/**
 	 * @var Queue_Collection
@@ -27,7 +34,7 @@ class Process extends Command {
 	 *          the process will run until it meets a fatal error
 	 *          (e.g., out of memory).
 	 */
-	private $timelimit = 300;
+	private $timelimit;
 
 	public function __construct( Queue_Collection $queue_collection, DI\FactoryInterface $container ) {
 		$this->queues    = $queue_collection;
@@ -47,9 +54,16 @@ class Process extends Command {
 		return [
 			[
 				'type'        => 'positional',
-				'name'        => 'queue',
+				'name'        => self::ARG_QUEUE,
 				'optional'    => false,
 				'description' => __( 'The name of the Queue.', 'tribe' ),
+			],
+			[
+				'type'        => 'assoc',
+				'name'        => self::ARG_TIMELIMIT,
+				'optional'    => true,
+				'description' => __( 'The max process execution in seconds.', 'tribe' ),
+				'default'     => self::DEFAULT_TIMELIMIT,
 			],
 		];
 	}
@@ -59,7 +73,8 @@ class Process extends Command {
 			WP_CLI::error( __( 'You must specify which queue you wish to process.', 'tribe' ) );
 		}
 
-		$queue_name = $args[0];
+		[ $queue_name ]  = $args;
+		$this->timelimit = (int) get_flag_value( $assoc_args, self::ARG_TIMELIMIT, self::DEFAULT_TIMELIMIT );
 
 		if ( ! array_key_exists( $queue_name, $this->queues->queues() ) ) {
 			WP_CLI::error( __( "That queue name doesn't appear to be valid.", 'tribe' ) );

--- a/src/Queues/README.md
+++ b/src/Queues/README.md
@@ -8,7 +8,7 @@ time consuming, or network-dependent tasks.
 While it is possible (and in rare cases appropriate) to have multiple queues, most often
 a project will use a single default queue. Using the DI container, your class constructor
 should receive a `\Tribe\Libs\Queues\Contracts\Queue`. Autowiring should take care of the
-reset to give you an instance of the appropriate queue class with the configured backend.
+rest to give you an instance of the appropriate queue class with the configured backend.
 
 ```php
 class Example_Class {
@@ -133,6 +133,13 @@ Using the system crontab, set up a job to run every 5 minutes to kick off the qu
 task will run for approximately five minutes, polling the queue every second for something to do
 (and sitting idle if there is nothing). After the five-minute time limit, the process will gracefully
 terminate.
+
+You can customize the timelimit with the `--timelimit=<time in seconds>` option, e.g. to change from the default
+`300` to `500` seconds:
+
+```bash
+wp s1 queues process default --timelimit=500
+```
 
 Along with the cron to process the queue, also set a cron to clean up old data from the queue.
 `wp s1 queues cleanup <queue-name>`


### PR DESCRIPTION
Replaces https://github.com/moderntribe/tribe-libs/pull/86/ to customize the queue processing time using the `--timeout=` option.