### PR TITLE
Feature/gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore paths when git creates an archive of this package
+/.gitattributes         export-ignore
+/.github                export-ignore
+/.gitignore             export-ignore
+/monorepo.sh            export-ignore
+/monorepo-builder.php   export-ignore
+/tests                  export-ignore
+/dev                    export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added `.gitattributes` file to make package smaller
 
 ## 3.4.7 - 2021-11-22
 - Added `--timeout=<time in seconds>` to the `wp s1 queues process` command


### PR DESCRIPTION
Adds a `.gitattributes` file with export-ignore declarations. 

When this package is pulled into other projects as a dependency (e.g. via composer), it will only include the folders/files it needs to run in a production environment, shrinking the package size and number of files. 