### PR TITLE
Queues: Make Task instances with the container when being run from WP cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Updated Queue Tasks run via WordPress cron to be created by the container so that dependency injection works.
 
 ## 3.4.8 - 2021-11-29
 - Added `.gitattributes` file to make package smaller

--- a/src/Queues/Backends/Mock_Backend.php
+++ b/src/Queues/Backends/Mock_Backend.php
@@ -29,19 +29,18 @@ class Mock_Backend implements Backend {
 	 */
 	public function dequeue( string $queue_name ): Message {
 		if ( array_key_exists( $queue_name, $this->queues ) && ! empty( $this->queues[ $queue_name ] ) ) {
-			$message = reset( $this->queues[ $queue_name ] );
-
-			// Remove from the stack after use to mark as done
-			unset( $this->queues[ $queue_name ][0] );
-
-			return $message;
+			return reset( $this->queues[ $queue_name ] );
 		}
 
 		throw new RuntimeException( 'No messages available to reserve.' );
 	}
 
 	public function ack( string $job_id, string $queue_name ) {
-		// does nothing
+		if ( ! isset( $this->queues[ $queue_name ][0] ) ) {
+			return;
+		}
+
+		unset( $this->queues[ $queue_name ][0] );
 	}
 
 	public function nack( string $job_id, string $queue_name ) {

--- a/src/Queues/Backends/Mock_Backend.php
+++ b/src/Queues/Backends/Mock_Backend.php
@@ -14,7 +14,7 @@ use Tribe\Libs\Queues\Message;
 class Mock_Backend implements Backend {
 
 	/**
-	 * @var array<string, list<string>>
+	 * @var array<string, Message[]>
 	 */
 	private $queues = [];
 

--- a/src/Queues/Backends/Mock_Backend.php
+++ b/src/Queues/Backends/Mock_Backend.php
@@ -1,8 +1,8 @@
-<?php
-
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\Queues\Backends;
 
+use RuntimeException;
 use Tribe\Libs\Queues\Contracts\Backend;
 use Tribe\Libs\Queues\Message;
 
@@ -12,7 +12,10 @@ use Tribe\Libs\Queues\Message;
  * A trivial backend for use when running tests
  */
 class Mock_Backend implements Backend {
-	/** @var array[] */
+
+	/**
+	 * @var array<string, list<string>>
+	 */
 	private $queues = [];
 
 	public function enqueue( string $queue_name, Message $m ) {
@@ -20,23 +23,29 @@ class Mock_Backend implements Backend {
 	}
 
 	/**
-	 * @param string $queue_name
+	 * @param  string  $queue_name
 	 *
 	 * @return Message The first message in the queue. Nothing will be reserved.
 	 */
 	public function dequeue( string $queue_name ): Message {
 		if ( array_key_exists( $queue_name, $this->queues ) && ! empty( $this->queues[ $queue_name ] ) ) {
-			return reset( $this->queues[ $queue_name ] );
+			$message = reset( $this->queues[ $queue_name ] );
+
+			// Remove from the stack after use to mark as done
+			unset( $this->queues[ $queue_name ][0] );
+
+			return $message;
 		}
-		throw new \RuntimeException( 'No messages available to reserve.' );
+
+		throw new RuntimeException( 'No messages available to reserve.' );
 	}
 
 	public function ack( string $job_id, string $queue_name ) {
-		return; // does nothing
+		// does nothing
 	}
 
 	public function nack( string $job_id, string $queue_name ) {
-		return; // does nothing
+		// does nothing
 	}
 
 	public function get_type(): string {
@@ -59,4 +68,5 @@ class Mock_Backend implements Backend {
 	public function cleanup() {
 		$this->queues = [];
 	}
+
 }

--- a/src/Queues/Backends/Mock_Backend.php
+++ b/src/Queues/Backends/Mock_Backend.php
@@ -36,11 +36,13 @@ class Mock_Backend implements Backend {
 	}
 
 	public function ack( string $job_id, string $queue_name ) {
-		if ( ! isset( $this->queues[ $queue_name ][0] ) ) {
+		$id = (int) $job_id;
+
+		if ( ! isset( $this->queues[ $queue_name ][ $id ] ) ) {
 			return;
 		}
 
-		unset( $this->queues[ $queue_name ][0] );
+		unset( $this->queues[ $queue_name ][ $id ] );
 	}
 
 	public function nack( string $job_id, string $queue_name ) {

--- a/src/Queues/Queues_Subscriber.php
+++ b/src/Queues/Queues_Subscriber.php
@@ -11,21 +11,23 @@ class Queues_Subscriber extends Abstract_Subscriber {
 	}
 
 	protected function cron(): void {
-		if ( ! defined( 'DISABLE_WP_CRON' ) || false === DISABLE_WP_CRON ) {
-			add_filter( 'cron_schedules', function ( $schedules ) {
-				return $this->container->get( Cron::class )->add_interval( $schedules );
-			}, 10, 1 );
-
-			add_action( 'admin_init', function (): void {
-				$this->container->get( Cron::class )->schedule_cron();
-			}, 10, 0 );
-
-			add_action( Cron::CRON_ACTION, function (): void {
-				foreach ( $this->container->get( Queue_Collection::class )->queues() as $queue ) {
-					$this->container->get( Cron::class )->process_queues( $queue );
-					$this->container->get( Cron::class )->cleanup( $queue );
-				}
-			}, 10, 0 );
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
+			return;
 		}
+
+		add_filter( 'cron_schedules', function ( $schedules ) {
+			return $this->container->get( Cron::class )->add_interval( $schedules );
+		}, 10, 1 );
+
+		add_action( 'admin_init', function (): void {
+			$this->container->get( Cron::class )->schedule_cron();
+		}, 10, 0 );
+
+		add_action( Cron::CRON_ACTION, function (): void {
+			foreach ( $this->container->get( Queue_Collection::class )->queues() as $queue ) {
+				$this->container->get( Cron::class )->process_queues( $queue );
+				$this->container->get( Cron::class )->cleanup( $queue );
+			}
+		}, 10, 0 );
 	}
 }

--- a/tests/integration/Tribe/Libs/Queues/CronTest.php
+++ b/tests/integration/Tribe/Libs/Queues/CronTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Queues;
+
+use Codeception\TestCase\WPTestCase;
+use DI\ContainerBuilder;
+use Tribe\Libs\Queues\Backends\Mock_Backend;
+use Tribe\Libs\Queues\Contracts\Task;
+
+final class CronTest extends WPTestCase {
+
+	public function test_it_schedules_the_queue_cron(): void {
+		$cron = new Cron( ( new ContainerBuilder() )->build() );
+
+		add_filter( 'cron_schedules', static function ( $schedules ) use ( $cron ) {
+			return $cron->add_interval( $schedules );
+		}, 10, 1 );
+
+		$schedules = wp_get_schedules();
+
+		$this->assertArrayHasKey( Cron::FREQUENCY, $schedules );
+
+		$cron->schedule_cron();
+
+		$events = _get_cron_array();
+
+		foreach ( $events as $hooks ) {
+			if ( isset( $hooks[ Cron::CRON_ACTION ] ) ) {
+				$this->assertTrue( true );
+				break;
+			}
+
+			$this->assertFalse( false );
+		}
+	}
+
+	public function test_it_processes_the_queue(): void {
+		$task = new class implements Task {
+			public function handle( array $args ): bool {
+				return true;
+			}
+		};
+
+		$builder = new ContainerBuilder();
+		$builder->addDefinitions( [
+			'TestTask' => $task,
+		] );
+
+		$backend = new Mock_Backend();
+		$cron    = new Cron( $builder->build() );
+
+		$message = new Message( 'TestTask', [], 10, 'test_task' );
+
+		$backend->enqueue( DefaultQueue::NAME, $message );
+
+		$this->assertSame( 1, $backend->count( DefaultQueue::NAME ) );
+
+		$queue = new DefaultQueue( $backend );
+
+		$cron->process_queues( $queue );
+
+		$this->assertSame( 0, $backend->count( DefaultQueue::NAME ) );
+	}
+
+	public function test_it_cleans_up_the_queue(): void {
+		$cron    = new Cron( ( new ContainerBuilder() )->build() );
+		$backend = new Mock_Backend();
+		$message = new Message( 'TestTask', [], 10, 'test_task' );
+		$queue   = new DefaultQueue( $backend );
+
+		$backend->enqueue( DefaultQueue::NAME, $message );
+		$this->assertSame( 1, $backend->count( DefaultQueue::NAME ) );
+		$cron->cleanup( $queue );
+		$this->assertSame( 0, $backend->count( DefaultQueue::NAME ) );
+	}
+
+}

--- a/tests/integration/Tribe/Libs/Queues/CronTest.php
+++ b/tests/integration/Tribe/Libs/Queues/CronTest.php
@@ -49,7 +49,7 @@ final class CronTest extends WPTestCase {
 		$backend = new Mock_Backend();
 		$cron    = new Cron( $builder->build() );
 
-		$message = new Message( 'TestTask', [], 10, 'test_task' );
+		$message = new Message( 'TestTask', [], 10, '0' );
 
 		$backend->enqueue( DefaultQueue::NAME, $message );
 
@@ -77,7 +77,7 @@ final class CronTest extends WPTestCase {
 		$backend = new Mock_Backend();
 		$cron    = new Cron( $builder->build() );
 
-		$message = new Message( 'TaskDoesNotExist', [], 10, 'test_task' );
+		$message = new Message( 'TaskDoesNotExist', [], 10, '0' );
 
 		$backend->enqueue( DefaultQueue::NAME, $message );
 


### PR DESCRIPTION
Adds the [same functionality](https://github.com/moderntribe/tribe-libs/pull/91) we added to the CLI queue processor to load task instances from the container to support auto wired dependency injection.