### PR TITLE
Update Taxonomy Generator Templates to Match PHPCS Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-
+- Fixed incorrect phpcs formatting for taxonomy generator templates.
 ## 3.4.8 - 2021-11-29
 - Added `.gitattributes` file to make package smaller
 - Added the Pipeline feature

--- a/src/Generators/templates/taxonomies/config.php
+++ b/src/Generators/templates/taxonomies/config.php
@@ -5,18 +5,23 @@ namespace Tribe\Project\Taxonomies\%1$s;
 use Tribe\Libs\Taxonomy\Taxonomy_Config;
 
 class Config extends Taxonomy_Config {
-	protected $taxonomy = '%4$s';
-	protected $post_types = [ %5$s ];
+
+	protected string $taxonomy = '%4$s';
+
+	/**
+	 * @var string[]
+	 */
+	protected array $post_types = [ %5$s ];
 
 	protected $version = 0;
 
-	public function get_args() {
+	public function get_args(): array {
 		return [
 			'hierarchical' => false,
 		];
 	}
 
-	public function get_labels() {
+	public function get_labels(): array {
 		return [
 			'singular' => __( '%2$s', 'tribe' ),
 			'plural'   => __( '%3$s', 'tribe' ),
@@ -24,7 +29,7 @@ class Config extends Taxonomy_Config {
 		];
 	}
 
-	public function default_terms() {
+	public function default_terms(): array {
 		return [];
 	}
 }

--- a/src/Generators/templates/taxonomies/subscriber.php
+++ b/src/Generators/templates/taxonomies/subscriber.php
@@ -6,5 +6,7 @@ namespace Tribe\Project\Taxonomies\%1$s;
 use Tribe\Libs\Taxonomy\Taxonomy_Subscriber;
 
 class Subscriber extends Taxonomy_Subscriber {
+
 	protected $config_class   = Config::class;
+
 }

--- a/src/Generators/templates/taxonomies/taxonomy.php
+++ b/src/Generators/templates/taxonomies/taxonomy.php
@@ -5,5 +5,7 @@ namespace Tribe\Project\Taxonomies\%1$s;
 use Tribe\Libs\Taxonomy\Term_Object;
 
 class %1$s extends Term_Object {
+
 	public const NAME = '%2$s';
+
 }


### PR DESCRIPTION
Fixes some phpcs issues when generating a taxonomy with `so wp s1 generate tax`