### PR TITLE
Fixes missing post titles in the P2P metabox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Fixed missing post titles in the P2P metabox
 
 ## 3.4.10 - 2022-02-11
 - Fixed nesting issue when using ACF classes to build Flexible Content Fields with Layout Fields in [#105](https://github.com/moderntribe/tribe-libs/pull/105)

--- a/src/P2P/Titles_Filter.php
+++ b/src/P2P/Titles_Filter.php
@@ -31,7 +31,7 @@ class Titles_Filter {
 	 */
 	public function filter_connection_name( $title, $object, $connection_type ) {
 
-		if ( empty($title) && $object instanceof \WP_Post ) {
+		if ( empty( $title ) && $object instanceof \WP_Post ) {
 			$title = $object->post_title;
 		}
 
@@ -61,7 +61,7 @@ class Titles_Filter {
 	 */
 	public function filter_candidate_name( $title, $object ) {
 
-		if ( empty($title) && $object instanceof \WP_Post ) {
+		if ( empty( $title ) && $object instanceof \WP_Post ) {
 			$title = $object->post_title;
 		}
 

--- a/src/P2P/Titles_Filter.php
+++ b/src/P2P/Titles_Filter.php
@@ -30,6 +30,11 @@ class Titles_Filter {
 	 * @filter p2p_connected_title
 	 */
 	public function filter_connection_name( $title, $object, $connection_type ) {
+
+		if ( empty($title) && $object instanceof \WP_Post ) {
+			$title = $object->post_title;
+		}
+
 		if ( empty( $this->connection_types ) ) {
 			return $title;
 		}
@@ -55,6 +60,11 @@ class Titles_Filter {
 	 * @filter p2p_candidate_title
 	 */
 	public function filter_candidate_name( $title, $object ) {
+
+		if ( empty($title) && $object instanceof \WP_Post ) {
+			$title = $object->post_title;
+		}
+
 		if ( empty( $this->connection_types ) ) {
 			return $title;
 		}


### PR DESCRIPTION
- Based on [external PR](https://github.com/moderntribe/harvard-school-public-health/pull/23)