### PR TITLE
Bugfix/p2p title hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Fixed Missing titles and missing post type prefixes in P2P metaboxes (take 2)
 
 ## 3.4.11 - 2022-03-23
 - Fixed missing post titles in the P2P metabox

--- a/src/P2P/P2P_Subscriber.php
+++ b/src/P2P/P2P_Subscriber.php
@@ -26,11 +26,11 @@ class P2P_Subscriber extends Abstract_Subscriber {
 	}
 
 	protected function title_filters(): void {
-		add_action( 'p2p_connected_title', function ( $title, $object, $connection_type ) {
-			$this->container->get( Titles_Filter::class )->filter_connection_name( $title, $object, $connection_type );
+		add_filter( 'p2p_connected_title', function ( $title, $object, $connection_type ) {
+			return $this->container->get( Titles_Filter::class )->filter_connection_name( $title, $object, $connection_type );
 		}, 10, 3 );
-		add_action( 'p2p_candidate_title', function ( $title, $object ) {
-			$this->container->get( Titles_Filter::class )->filter_candidate_name( $title, $object );
+		add_filter( 'p2p_candidate_title', function ( $title, $object ) {
+			return $this->container->get( Titles_Filter::class )->filter_candidate_name( $title, $object );
 		}, 10, 3 );
 	}
 

--- a/src/P2P/Titles_Filter.php
+++ b/src/P2P/Titles_Filter.php
@@ -30,15 +30,9 @@ class Titles_Filter {
 	 * @filter p2p_connected_title
 	 */
 	public function filter_connection_name( $title, $object, $connection_type ) {
-
-		if ( empty( $title ) && $object instanceof \WP_Post ) {
-			$title = $object->post_title;
-		}
-
 		if ( empty( $this->connection_types ) ) {
 			return $title;
 		}
-
 		$p2p_id = $connection_type->name;
 		if ( !in_array( $p2p_id, $this->connection_types_to_label(), true ) ) {
 			return $title;
@@ -60,11 +54,6 @@ class Titles_Filter {
 	 * @filter p2p_candidate_title
 	 */
 	public function filter_candidate_name( $title, $object ) {
-
-		if ( empty( $title ) && $object instanceof \WP_Post ) {
-			$title = $object->post_title;
-		}
-
 		if ( empty( $this->connection_types ) ) {
 			return $title;
 		}

--- a/src/P2P/Titles_Filter.php
+++ b/src/P2P/Titles_Filter.php
@@ -75,7 +75,9 @@ class Titles_Filter {
 	}
 
 	private function connection_types_to_label() {
-		return $this->connection_types;
+		return array_map( static function ( $connection_type ) {
+			return $connection_type::NAME;
+		}, $this->connection_types );
 	}
 
 	private function get_connection_type() {


### PR DESCRIPTION
Corrects several issues related to P2P title filtering.
1. The hooks were added incorrectly using an `action` with no return value which was causing no post titles to display in the editor metabox.
2. The array of connections to add the post type as as prefix on the post title in the metabox was incorrectly being evaluated against the connection class, not the connection name.

[SQONE-692]

[SQONE-692]: https://moderntribe.atlassian.net/browse/SQONE-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ