### PR TITLE
Block view generator update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Updated the `wp s1 genereate block` command to generate block model views using the container as a companion update to [#970](https://github.com/moderntribe/square-one/pull/970).
 
 ## 3.4.12 - 2022-03-24
 - Fixed Missing titles and missing post type prefixes in P2P metaboxes (take 2)

--- a/src/Generators/templates/block/template.php.tmpl
+++ b/src/Generators/templates/block/template.php.tmpl
@@ -3,7 +3,12 @@
 use Tribe\Project\Blocks\Types\%1$s\%1$s_Model;
 
 /**
- * @var array $args Arguments passed to the template
+ * @var array $args ACF block data.
  */
-$model = new %1$s_Model( $args['block'] );
-get_template_part( 'components/blocks/%2$s/%2$s', null, $model->get_data() );
+$model = tribe_project()->container()->make( %1$s_Model::class, $args );
+
+get_template_part(
+	'components/blocks/%2$s/%2$s',
+	'',
+	$model->get_data()
+);


### PR DESCRIPTION
Companion update for https://github.com/moderntribe/square-one/pull/970 to generate block views to match the changes via `so wp s1 generate block $name`

Generated a Hello_World block as a test, here's the helloworld.php model view:

```php
<?php declare(strict_types=1);

use Tribe\Project\Blocks\Types\Hello_World\Hello_World_Model;

/**
 * @var array $args ACF block data.
 */
$model = tribe_project()->container()->make( Hello_World_Model::class, $args );

get_template_part(
	'components/blocks/hello_world/hello_world',
	'',
	$model->get_data()
);
```