### PR TITLE
Add With_Get_Field.php ACF trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added: `With_Get_Field` ACF trait.
 
 ## 3.4.14 - 2022-04-26
 - Fixed: tests that use `wp_mail` with the latest WordPress, making validation fail with `Invalid address:  (From): wordpress@localhost` by adjusting the test domains we use to build a valid email address.

--- a/src/ACF/Traits/With_Get_Field.php
+++ b/src/ACF/Traits/With_Get_Field.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\ACF\Traits;
+
+trait With_Get_Field {
+
+	/**
+	 * Retrieve data from an ACF field.
+	 *
+	 * Check to support nullable type properties in components.
+	 * ACF will in some cases return and empty string when we may want it to be null.
+	 * This allows us to always determine the default.
+	 *
+	 * @param  int|string  $key         ACF key identifier.
+	 * @param  mixed       $default     The default value if the field doesn't exist.
+	 * @param  mixed       $identifier  The ACF Identifier, e.g. post_id.
+	 *
+	 * @return mixed
+	 */
+	public function get( $key, $default = false, $identifier = false ) {
+		$value = get_field( $key, $identifier );
+
+		return ! empty( $value )
+			? $value
+			: $default;
+	}
+
+}


### PR DESCRIPTION
- Adds this handy trait for use in block models and other objects that need to retrieve ACF field data.