### PR TITLE
Feature: mutable block config

### DIFF
--- a/src/ACF/ACF_Configuration.php
+++ b/src/ACF/ACF_Configuration.php
@@ -49,7 +49,7 @@ abstract class ACF_Configuration {
 	 * Get all the attributes, formatted as
 	 * an ACF-ready array
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	public function get_attributes() {
 		return [ $this->attributes ];
@@ -69,4 +69,5 @@ abstract class ACF_Configuration {
 
 		return null;
 	}
+
 }

--- a/src/ACF/Block_Config.php
+++ b/src/ACF/Block_Config.php
@@ -1,18 +1,20 @@
-<?php
-declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF;
 
+use InvalidArgumentException;
+
 abstract class Block_Config {
+
 	public const NAME = '';
 
 	/**
-	 * @var array
+	 * @var \Tribe\Libs\ACF\Field[]
 	 */
 	protected $fields = [];
 
 	/**
-	 * @var Block
+	 * @var \Tribe\Libs\ACF\Block
 	 */
 	protected $block;
 
@@ -24,7 +26,7 @@ abstract class Block_Config {
 	abstract public function add_block();
 
 	protected function add_fields() {
-		//overwrite in sub class to add fields
+		//overwrite in subclass to add fields
 	}
 
 	/**
@@ -39,7 +41,7 @@ abstract class Block_Config {
 	}
 
 	/**
-	 * @param Block $block
+	 * @param  \Tribe\Libs\ACF\Block  $block
 	 *
 	 * @return $this
 	 */
@@ -56,14 +58,16 @@ abstract class Block_Config {
 		return $this;
 	}
 
-	public function get_block() {
+	public function get_block(): ?Block {
 		return $this->block;
 	}
 
 	/**
-	 * @param Field $field
+	 * Append a field object to the block.
 	 *
-	 * @return Block_Config
+	 * @param  \Tribe\Libs\ACF\Field  $field
+	 *
+	 * @return $this
 	 */
 	public function add_field( Field $field ): Block_Config {
 		$this->fields[] = $field;
@@ -72,11 +76,31 @@ abstract class Block_Config {
 	}
 
 	/**
-	 * @return Group
+	 * Get the current field objects.
+	 *
+	 * @return \Tribe\Libs\ACF\Field[]
 	 */
-	public function get_field_group() {
+	public function get_fields(): array {
+		return $this->fields;
+	}
+
+	/**
+	 * Allow fields to be mutated after run time for block middleware
+	 * etc...
+	 *
+	 * @param  \Tribe\Libs\ACF\Field[]  $fields
+	 *
+	 * @return $this
+	 */
+	public function set_fields( array $fields ): Block_Config {
+		$this->fields = $fields;
+
+		return $this;
+	}
+
+	public function get_field_group(): Group {
 		if ( static::NAME == '' ) {
-			throw new \InvalidArgumentException( "Block requires a NAME constant in " . static::class );
+			throw new InvalidArgumentException( 'Block requires a NAME constant in ' . static::class );
 		}
 
 		$group = new Group( static::NAME, [

--- a/src/ACF/Block_Config.php
+++ b/src/ACF/Block_Config.php
@@ -23,10 +23,26 @@ abstract class Block_Config {
 		$this->add_fields();
 	}
 
+	/**
+	 * Add an ACF Block to the Block_Config
+	 *
+	 * @see \Tribe\Libs\ACF\Block_Config::set_block()
+	 *
+	 * @return void
+	 */
 	abstract public function add_block();
 
+	/**
+	 * Override this method in your subclass to add fields.
+	 *
+	 * @TODO we should make this an abstract in the next major version of tribe-libs.
+	 *
+	 * @see \Tribe\Libs\ACF\Block_Config::add_section()
+	 * @see \Tribe\Libs\ACF\Block_Config::add_field()
+	 *
+	 * @return void
+	 */
 	protected function add_fields() {
-		//overwrite in subclass to add fields
 	}
 
 	/**
@@ -76,7 +92,7 @@ abstract class Block_Config {
 	}
 
 	/**
-	 * Get the current field objects.
+	 * Get the currently set field objects.
 	 *
 	 * @return \Tribe\Libs\ACF\Field[]
 	 */

--- a/src/ACF/Contracts/Has_Sub_Fields.php
+++ b/src/ACF/Contracts/Has_Sub_Fields.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\ACF\Contracts;
+
+use Tribe\Libs\ACF\Field;
+
+/**
+ * Used in combination with the subfield trait.
+ *
+ * @see \Tribe\Libs\ACF\Traits\With_Sub_Fields
+ */
+interface Has_Sub_Fields {
+
+	/**
+	 * Add a field to a field type that supports subfields.
+	 *
+	 * @param  \Tribe\Libs\ACF\Field  $field
+	 *
+	 * @return static
+	 */
+	public function add_field( Field $field );
+
+
+	public function get_sub_field_attributes(): array;
+
+}

--- a/src/ACF/Contracts/Has_Sub_Fields.php
+++ b/src/ACF/Contracts/Has_Sub_Fields.php
@@ -20,7 +20,14 @@ interface Has_Sub_Fields {
 	 */
 	public function add_field( Field $field );
 
+	/**
+	 * @return \Tribe\Libs\ACF\Field[]
+	 */
+	public function get_fields(): array;
 
+	/**
+	 * @return array[]
+	 */
 	public function get_sub_field_attributes(): array;
 
 }

--- a/src/ACF/Field.php
+++ b/src/ACF/Field.php
@@ -1,13 +1,14 @@
-<?php
-
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF;
 
 class Field extends ACF_Configuration {
+
 	protected $key_prefix = 'field';
 
 	public function __construct( $key, $attributes = []) {
 		$this->attributes = $attributes;
 		parent::__construct( $key );
 	}
+
 }

--- a/src/ACF/Field_Group.php
+++ b/src/ACF/Field_Group.php
@@ -1,13 +1,14 @@
-<?php
-
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF;
 
+use Tribe\Libs\ACF\Contracts\Has_Sub_Fields;
 use Tribe\Libs\ACF\Traits\With_Sub_Fields;
 
-class Field_Group extends Field implements ACF_Aggregate {
+class Field_Group extends Field implements ACF_Aggregate, Has_Sub_Fields {
+
 	use With_Sub_Fields;
-	
+
 	protected $key_prefix = 'field';
 
 	/**
@@ -25,4 +26,5 @@ class Field_Group extends Field implements ACF_Aggregate {
 
 		return [ $attributes ];
 	}
+
 }

--- a/src/ACF/Field_Section.php
+++ b/src/ACF/Field_Section.php
@@ -1,11 +1,12 @@
-<?php
-declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF;
 
+use Tribe\Libs\ACF\Contracts\Has_Sub_Fields;
 use Tribe\Libs\ACF\Traits\With_Sub_Fields;
 
-class Field_Section extends Field implements ACF_Aggregate {
+class Field_Section extends Field implements ACF_Aggregate, Has_Sub_Fields {
+
 	use With_Sub_Fields;
 
 	/**
@@ -29,14 +30,14 @@ class Field_Section extends Field implements ACF_Aggregate {
 	}
 
 	/**
-	 * @return array
+	 * @return \Tribe\Libs\ACF\Field[]
 	 */
 	public function get_fields(): array {
 		return $this->fields;
 	}
 
 	/**
-	 * @return array
+	 * @return array[]
 	 */
 	public function get_attributes() {
 		return array_merge( [ $this->attributes ], $this->get_sub_field_attributes() );

--- a/src/ACF/Field_Section.php
+++ b/src/ACF/Field_Section.php
@@ -30,13 +30,6 @@ class Field_Section extends Field implements ACF_Aggregate, Has_Sub_Fields {
 	}
 
 	/**
-	 * @return \Tribe\Libs\ACF\Field[]
-	 */
-	public function get_fields(): array {
-		return $this->fields;
-	}
-
-	/**
 	 * @return array[]
 	 */
 	public function get_attributes() {

--- a/src/ACF/Flexible_Content.php
+++ b/src/ACF/Flexible_Content.php
@@ -1,9 +1,9 @@
-<?php
-
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF;
 
 class Flexible_Content extends Field {
+
 	/** @var Layout[] */
 	protected $layouts = [ ];
 
@@ -27,4 +27,5 @@ class Flexible_Content extends Field {
 
 		return [ $attributes ];
 	}
+
 }

--- a/src/ACF/Layout.php
+++ b/src/ACF/Layout.php
@@ -1,12 +1,14 @@
-<?php
-
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF;
 
+use Tribe\Libs\ACF\Contracts\Has_Sub_Fields;
 use Tribe\Libs\ACF\Traits\With_Sub_Fields;
 
-class Layout extends Field implements ACF_Aggregate {
+class Layout extends Field implements ACF_Aggregate, Has_Sub_Fields {
+
 	use With_Sub_Fields;
+
 	protected $key_prefix = 'layout';
 
 	public function get_attributes() {

--- a/src/ACF/Repeater.php
+++ b/src/ACF/Repeater.php
@@ -1,11 +1,12 @@
-<?php
-
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF;
 
+use Tribe\Libs\ACF\Contracts\Has_Sub_Fields;
 use Tribe\Libs\ACF\Traits\With_Sub_Fields;
 
-class Repeater extends Field implements ACF_Aggregate {
+class Repeater extends Field implements ACF_Aggregate, Has_Sub_Fields {
+
 	use With_Sub_Fields;
 
 	protected $key_prefix = 'field';

--- a/src/ACF/Traits/With_Sub_Fields.php
+++ b/src/ACF/Traits/With_Sub_Fields.php
@@ -1,11 +1,15 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\ACF\Traits;
 
 use Tribe\Libs\ACF\ACF_Configuration;
 use Tribe\Libs\ACF\Field;
 
+/**
+ * @mixin Field
+ */
 trait With_Sub_Fields {
+
 	/** @var Field[] */
 	protected $fields = [];
 
@@ -21,7 +25,9 @@ trait With_Sub_Fields {
 	}
 
 	/**
-	 * @return array
+	 * Get the attributes of all subfields.
+	 *
+	 * @return array[]
 	 */
 	public function get_sub_field_attributes(): array {
 		return array_merge( ... array_map( static function ( ACF_Configuration $field ) {

--- a/src/ACF/Traits/With_Sub_Fields.php
+++ b/src/ACF/Traits/With_Sub_Fields.php
@@ -7,10 +7,11 @@ use Tribe\Libs\ACF\Field;
 
 /**
  * @mixin Field
+ * @mixin \Tribe\Libs\ACF\Contracts\Has_Sub_Fields
  */
 trait With_Sub_Fields {
 
-	/** @var Field[] */
+	/** @var \Tribe\Libs\ACF\Field[] */
 	protected $fields = [];
 
 	/**
@@ -22,6 +23,13 @@ trait With_Sub_Fields {
 		$this->fields[] = $field;
 
 		return $this;
+	}
+
+	/**
+	 * @return \Tribe\Libs\ACF\Field[]
+	 */
+	public function get_fields(): array {
+		return $this->fields;
 	}
 
 	/**

--- a/src/Pipeline/Contracts/Pipeline.php
+++ b/src/Pipeline/Contracts/Pipeline.php
@@ -9,11 +9,12 @@ interface Pipeline {
 	/**
 	 * Set the traveler object being sent on the pipeline.
 	 *
-	 * @param  mixed  $traveler
+	 * @param  mixed  $passable
+	 * @param  array  $parameters Additional parameters that get passed through the stages.
 	 *
 	 * @return $this
 	 */
-	public function send( $traveler ): Pipeline;
+	public function send( $passable, array $parameters = [] ): Pipeline;
 
 	/**
 	 * Set the stops of the pipeline.

--- a/src/Pipeline/Pipeline.php
+++ b/src/Pipeline/Pipeline.php
@@ -62,6 +62,7 @@ class Pipeline implements PipelineContract {
 	 * Set the object being sent through the pipeline.
 	 *
 	 * @param mixed $passable
+	 * @param array $parameters
 	 *
 	 * @return $this
 	 */


### PR DESCRIPTION
> Note: These changes should not affect any existing versions of square-one using the `3.4.X` tags, they are just additions and not changes to any interfaces.

- Adds additional methods to the Block_Config to allow modification by upcoming Block MIddleware
- Adds new `Has_Sub_Fields` interface to work alongside the `With_Sub_Fields` trait. This way we can expect certain methods in our projects when working with Field objects.
- Fix the `send()` method in the Pipeline interface to properly match our implementation.
- General code/comment clean up.