### PR TITLE
Feature: update block generator templates escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Updated: `so wp s1 generate block <name>` will use `esc_html__()` instead of `__()` for field labels.
 
 ## 3.4.17 - 2022-06-20
 - Updated: Block_Config class to allow for mutation for upcoming block middleware.

--- a/src/Generators/templates/block/config.php.tmpl
+++ b/src/Generators/templates/block/config.php.tmpl
@@ -19,11 +19,11 @@ class %1$s extends Block_Config {
 
 	public function add_block(): void {
 		$this->set_block( new Block( self::NAME, [
-			'title'       => __( '%3$s', 'tribe' ),
-			'description' => __( 'A custom block by Modern Tribe', 'tribe' ), // TODO: describe the block
+			'title'       => esc_html__( '%3$s', 'tribe' ),
+			'description' => esc_html__( 'A custom block by Modern Tribe', 'tribe' ), // TODO: describe the block
 			// TODO: set SVG icon
 			'icon'        => '<svg viewBox="0 0 146.3 106.3" xmlns="http://www.w3.org/2000/svg"><path fill="#16d690" d="M145.2 106.3l-72.6-64L26.5 1.2 0 106.3z"/><path fill="#21a6cb" d="M145.2 106.3H0l72.6-64 46-41.1z"/><path fill="#008f8f" d="M72.6 42.3l72.6 64H0z"/></svg>',
-			'keywords'    => [ __( 'placeholder', 'tribe' ) ], // TODO: select appropriate keywords
+			'keywords'    => [ esc_html__( 'placeholder', 'tribe' ) ], // TODO: select appropriate keywords
 			'category'    => 'common', // core categories: text, media, design, widgets, theme, embed
 			'supports'    => [
 				'align'  => false,
@@ -38,14 +38,14 @@ class %1$s extends Block_Config {
 	 */
 	public function add_fields(): void {
 		// Content Fields
-		$this->add_section( new Field_Section( self::SECTION_CONTENT, __( 'Content', 'tribe' ), 'accordion' ) )
+		$this->add_section( new Field_Section( self::SECTION_CONTENT, esc_html__( 'Content', 'tribe' ), 'accordion' ) )
 			->add_field( new Field( self::NAME . '_' . self::TITLE, [
-					'label' => __( 'Title', 'tribe' ),
+					'label' => esc_html__( 'Title', 'tribe' ),
 					'name'  => self::TITLE,
 					'type'  => 'text',
 				] )
 			)->add_field( new Field( self::NAME . '_' . self::DESCRIPTION, [
-					'label'        => __( 'Description', 'tribe' ),
+					'label'        => esc_html__( 'Description', 'tribe' ),
 					'name'         => self::DESCRIPTION,
 					'type'         => 'wysiwyg',
 					'toolbar'      => 'basic',
@@ -54,7 +54,7 @@ class %1$s extends Block_Config {
 			);
 
 		// Setting Fields
-		$this->add_section( new Field_Section( self::SECTION_SETTINGS, __( 'Settings', 'tribe' ), 'accordion' ) );
+		$this->add_section( new Field_Section( self::SECTION_SETTINGS, esc_html__( 'Settings', 'tribe' ), 'accordion' ) );
 	}
 
 }


### PR DESCRIPTION
Companion PR for https://github.com/moderntribe/square-one/pull/1006 so newly generated blocks using `wp s1 generate block <name>` will be escaped out of the box.