### PR TITLE
Feature: update block generators to support Post Loop Field Middleware generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added: `wp s1 generate block <name> --with-post-loop-middleware` that gives a base configuration for a block with Post Loop Middleware.
 
 ## 3.5.1 - 2022-08-05
 - Added: `With_Field_Prefix` trait to make fetching full key names easier for conditional logic and block middleware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 - Added: `wp s1 generate block <name> --with-post-loop-middleware` that gives a base configuration for a block with Post Loop Middleware.
+- Changed: The `Block_Config` class now uses the `With_Field_Prefix` out of the box so those methods are available to all blocks when needed.
 
 ## 3.5.1 - 2022-08-05
 - Added: `With_Field_Prefix` trait to make fetching full key names easier for conditional logic and block middleware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 - Added: `wp s1 generate block <name> --with-post-loop-middleware` that gives a base configuration for a block with Post Loop Middleware.
 - Changed: The `Block_Config` class now uses the `With_Field_Prefix` out of the box so those methods are available to all blocks when needed.
+- Changed: `Block_Config`'s generated with the block generator now use `\Tribe\Project\Blocks\Block_Category::CUSTOM_BLOCK_CATEGORY_SLUG` if the project has it available, otherwise it uses the `text` category.
 
 ## 3.5.1 - 2022-08-05
 - Added: `With_Field_Prefix` trait to make fetching full key names easier for conditional logic and block middleware.

--- a/src/ACF/Block_Config.php
+++ b/src/ACF/Block_Config.php
@@ -3,8 +3,11 @@
 namespace Tribe\Libs\ACF;
 
 use InvalidArgumentException;
+use Tribe\Libs\ACF\Traits\With_Field_Prefix;
 
 abstract class Block_Config {
+
+	use With_Field_Prefix;
 
 	public const NAME = '';
 

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -286,7 +286,7 @@ METHOD;
 	}
 
 	private function get_block_config_post_loop_middleware_method(): string {
-		return <<<METHOD
+		return <<<'METHOD'
 		
 	/**
 	 * @TODO Provide specific Post Loop Config and import to use statements.
@@ -311,7 +311,7 @@ METHOD;
 	}
 
 	private function get_block_model_post_loop_middleware_constructor(): string {
-		return <<<CONSTRUC
+		return <<<'CONSTRUC'
 		
 	protected Post_Loop_Repository $post_loop;
 

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -355,7 +355,7 @@ CONSTRUC;
 		$class = sprintf( '\Tribe\Project\Blocks\Types\%1$s\%1$s::class', $class_name );
 
 		return <<<DEFINITION
-				// TODO: use fully qualified class name
+				// TODO: replace class with an import "use" statement
 				$class    => [
 					Post_Loop_Field_Middleware::class,
 				],				

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -88,7 +88,7 @@ class Block_Generator extends Generator_Command {
 	}
 
 	private function make_component( $name, $dry_run, $with_post_loop_middleware ): void {
-		WP_CLI::runcommand( sprintf( 's1 generate component blocks/%s %s %s', $name, $dry_run ? '--' . self::OPTION_DRY_RUN : '', $with_post_loop_middleware ? '--' . Component_Generator::OPTION_WITH_POST_LOOP_MIDDLEWARE : '' ), [
+		WP_CLI::runcommand( sprintf( 's1 generate component blocks/%s %s %s', $name, $dry_run ? '--' . Component_Generator::OPTION_DRY_RUN : '', $with_post_loop_middleware ? '--' . Component_Generator::OPTION_WITH_POST_LOOP_MIDDLEWARE : '' ), [
 			'return'     => false,
 			'launch'     => false,
 			'exit_error' => true,

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -118,7 +118,7 @@ class Block_Generator extends Generator_Command {
 
 		if ( $this->supports_middelware ) {
 			if ( $with_middleware || $with_post_loop_middleware ) {
-				$middleware_use_statement = 'use Tribe\Project\Block_Middleware\Contracts\Has_Middleware_Params;';
+				$middleware_use_statement = "\r\n" . 'use Tribe\Project\Block_Middleware\Contracts\Has_Middleware_Params;';
 			}
 
 			if ( $with_post_loop_middleware ) {
@@ -135,7 +135,7 @@ class Block_Generator extends Generator_Command {
 		if ( $with_post_loop_middleware && $this->supports_middelware ) {
 			$middleware_method    = $this->get_block_config_post_loop_middleware_method();
 			$additional_constants = "public const SECTION_CARDS = 's-cards';\r\n    public const POST_LIST = 'post_list';\r\n";
-			$additional_section   = "\r\n" . '		// Post loop fields will be added to this section via block middleware. ' . "\r\n" . '		$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
+			$additional_section   = "\r\n\r\n" . '		// Post loop fields will be added to this section via block middleware. ' . "\r\n" . '		$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
 		} elseif ( $with_middleware && $this->supports_middelware ) {
 			$middleware_method = $this->get_block_config_middleware_method();
 		}
@@ -181,7 +181,7 @@ class Block_Generator extends Generator_Command {
 			$this->supports_middelware ? 'init_data' : 'get_data', // method differs depending on the version of Square one
 			( $with_post_loop_middleware && $this->supports_middelware ) ? "use Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? $this->get_block_model_post_loop_middleware_constructor() : '',
-			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),', $this->controller_classname( $component_name ), $class_name ) : ''
+			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( '			%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n", $this->controller_classname( $component_name ), $class_name ) : ''
 		);
 
 		if ( $dry_run ) {

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -122,10 +122,8 @@ class Block_Generator extends Generator_Command {
 
 		if ( $with_post_loop_middleware && $this->supports_middelware ) {
 			$middleware_method    = $this->get_block_config_post_loop_middleware_method();
-			$additional_constants = "public const SECTION_CARDS = 's-cards';\r\n
-									public const POST_LIST = 'post_list';\r\n";
-			$additional_section   = '// Post loop fields will be added to this section via block middleware. ' . "\r\n" .
-									'$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
+			$additional_constants = "public const SECTION_CARDS = 's-cards';\r\n    public const POST_LIST = 'post_list';\r\n";
+			$additional_section   = '// Post loop fields will be added to this section via block middleware. ' . "\r\n" . ' $this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
 		} elseif ( $with_middleware && $this->supports_middelware ) {
 			$middleware_method = $this->get_block_config_middleware_method();
 		}

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -123,7 +123,7 @@ class Block_Generator extends Generator_Command {
 		if ( $with_post_loop_middleware && $this->supports_middelware ) {
 			$middleware_method    = $this->get_block_config_post_loop_middleware_method();
 			$additional_constants = "public const SECTION_CARDS = 's-cards';\r\n    public const POST_LIST = 'post_list';\r\n";
-			$additional_section   = '// Post loop fields will be added to this section via block middleware. ' . "\r\n" . ' $this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
+			$additional_section   = "\r\n" . '// Post loop fields will be added to this section via block middleware. ' . "\r\n" . '		$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
 		} elseif ( $with_middleware && $this->supports_middelware ) {
 			$middleware_method = $this->get_block_config_middleware_method();
 		}

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -114,8 +114,8 @@ class Block_Generator extends Generator_Command {
 			WP_CLI::warning( 'Sorry, this version of Square One does not support block middleware.' );
 		}
 
-		$middleware_use_statement = ( $with_middleware && $this->supports_middelware ) ? 'use Tribe\Project\Block_Middleware\Contracts\Has_Middleware_Params' : '';
-		$middleware_interface     = ( $with_middleware && $this->supports_middelware ) ? ' implements Has_Middleware_Params' : '';
+		$middleware_use_statement = ( $this->supports_middelware && ( $with_middleware || $with_post_loop_middleware ) ) ? 'use Tribe\Project\Block_Middleware\Contracts\Has_Middleware_Params;' : '';
+		$middleware_interface     = ( $this->supports_middelware && ( $with_middleware || $with_post_loop_middleware ) ) ? ' implements Has_Middleware_Params' : '';
 		$middleware_method        = '';
 		$additional_constants     = '';
 		$additional_section       = '';

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -281,7 +281,7 @@ class Block_Generator extends Generator_Command {
 		}
 
 		$definer_path      = $this->src_path . 'Block_Middleware/Block_Middleware_Definer.php';
-		$type_registration = sprintf( '%2$s// TODO: use fully qualified class name%2$s\Tribe\Project\Blocks\Types\%1$s\%1$s::class => [ %3$s ],', $class_name, "\t\t\t\t", "\r\n\t\t\t\t\tPost_Loop_Field_Middleware::class,\r\n\t\t\t\t" );
+		$type_registration = $this->get_post_loop_block_middleware_definition( $class_name );
 
 		if ( $dry_run ) {
 			WP_CLI::log( '[Dry Run] Skipping registration of block in Block_Middleware_Definer.php ' );
@@ -349,5 +349,16 @@ METHOD;
 	}
 			
 CONSTRUC;
+	}
+
+	private function get_post_loop_block_middleware_definition( string $class_name ): string {
+		$class = "\Tribe\Project\Blocks\Types\$class\$class::class";
+
+		return <<<DEFINITION
+				// TODO: use fully qualified class name
+				$class    => [
+					Post_Loop_Field_Middleware::class,
+				],
+DEFINITION;
 	}
 }

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -181,7 +181,7 @@ class Block_Generator extends Generator_Command {
 			$this->supports_middelware ? 'init_data' : 'get_data', // method differs depending on the version of Square one
 			( $with_post_loop_middleware && $this->supports_middelware ) ? "use Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? $this->get_block_model_post_loop_middleware_constructor() : '',
-			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "\r\n\t\t" . '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n", $this->controller_classname( $component_name ), $class_name ) : ''
+			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "\r\n\t\t\t" . '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n", $this->controller_classname( $component_name ), $class_name ) : ''
 		);
 
 		if ( $dry_run ) {

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -181,7 +181,7 @@ class Block_Generator extends Generator_Command {
 			$this->supports_middelware ? 'init_data' : 'get_data', // method differs depending on the version of Square one
 			( $with_post_loop_middleware && $this->supports_middelware ) ? "use Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? $this->get_block_model_post_loop_middleware_constructor() : '',
-			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "\r\n\t\t\t" . '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n", $this->controller_classname( $component_name ), $class_name ) : ''
+			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "\r\n\t\t\t" . '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),', $this->controller_classname( $component_name ), $class_name ) : ''
 		);
 
 		if ( $dry_run ) {

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -281,7 +281,7 @@ class Block_Generator extends Generator_Command {
 		}
 
 		$definer_path      = $this->src_path . 'Block_Middleware/Block_Middleware_Definer.php';
-		$type_registration = sprintf( '%2$s\Tribe\Project\Blocks\Types\%1$s\%1$s::class => [ %3$s, ], // TODO: use fully qualified class name', $class_name, "\t\t\t\t\t", "\r\n\t\t\t\tPost_Loop_Field_Middleware::class\r\n\t\t\t\t" );
+		$type_registration = sprintf( '%2$s\Tribe\Project\Blocks\Types\%1$s\%1$s::class => [ %3$s ], // TODO: use fully qualified class name', $class_name, "\t\t\t\t", "\r\n\t\t\t\t\tPost_Loop_Field_Middleware::class,\r\n\t\t\t\t" );
 
 		if ( $dry_run ) {
 			WP_CLI::log( '[Dry Run] Skipping registration of block middleware in Block_Middleware_Definer.php ' );

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -294,7 +294,7 @@ METHOD;
 	 * @return array<array{post_loop_field_configs: \Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config[]}>
 	 */
 	public function get_middleware_params(): array {
-		$config = new \Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config();
+		$config             = new \Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config();
 		$config->field_name = self::POST_LIST;
 		$config->group      = $this->get_section_key( self::SECTION_CARDS );
 		

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -359,6 +359,7 @@ CONSTRUC;
 				$class    => [
 					Post_Loop_Field_Middleware::class,
 				],
+				
 DEFINITION;
 	}
 }

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -281,10 +281,10 @@ class Block_Generator extends Generator_Command {
 		}
 
 		$definer_path      = $this->src_path . 'Block_Middleware/Block_Middleware_Definer.php';
-		$type_registration = sprintf( '%2$s\Tribe\Project\Blocks\Types\%1$s\%1$s::class => [ %3$s ], // TODO: use fully qualified class name', $class_name, "\t\t\t\t", "\r\n\t\t\t\t\tPost_Loop_Field_Middleware::class,\r\n\t\t\t\t" );
+		$type_registration = sprintf( '%2$s// TODO: use fully qualified class name%2$s\Tribe\Project\Blocks\Types\%1$s\%1$s::class => [ %3$s ],', $class_name, "\t\t\t\t", "\r\n\t\t\t\t\tPost_Loop_Field_Middleware::class,\r\n\t\t\t\t" );
 
 		if ( $dry_run ) {
-			WP_CLI::log( '[Dry Run] Skipping registration of block middleware in Block_Middleware_Definer.php ' );
+			WP_CLI::log( '[Dry Run] Skipping registration of block in Block_Middleware_Definer.php ' );
 		} else {
 			WP_CLI::log( 'Registering block in Block_Middleware_Definer.php ' );
 			$this->file_system->insert_into_existing_file( $definer_path, $type_registration, 'self::BLOCK_MIDDLEWARE' );

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -181,7 +181,7 @@ class Block_Generator extends Generator_Command {
 			$this->supports_middelware ? 'init_data' : 'get_data', // method differs depending on the version of Square one
 			( $with_post_loop_middleware && $this->supports_middelware ) ? "use Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? $this->get_block_model_post_loop_middleware_constructor() : '',
-			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "\r\n\t\t\t" . '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n\t\t\t", $this->controller_classname( $component_name ), $class_name ) : ''
+			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "\r\n\t\t" . '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n", $this->controller_classname( $component_name ), $class_name ) : ''
 		);
 
 		if ( $dry_run ) {

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -171,7 +171,7 @@ class Block_Generator extends Generator_Command {
 			$this->supports_middelware ? 'init_data' : 'get_data', // method differs depending on the version of Square one
 			( $with_post_loop_middleware && $this->supports_middelware ) ? "\r\nuse Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? $this->get_block_model_post_loop_middleware_constructor() : '',
-			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),", $this->controller_classname( $component_name ), $class_name ) : ''
+			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),', $this->controller_classname( $component_name ), $class_name ) : ''
 		);
 
 		if ( $dry_run ) {

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -135,7 +135,7 @@ class Block_Generator extends Generator_Command {
 		if ( $with_post_loop_middleware && $this->supports_middelware ) {
 			$middleware_method    = $this->get_block_config_post_loop_middleware_method();
 			$additional_constants = "public const SECTION_CARDS = 's-cards';\r\n    public const POST_LIST = 'post_list';\r\n";
-			$additional_section   = "\r\n\r\n" . '		// Post loop fields will be added to this section via block middleware. ' . "\r\n" . '		$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
+			$additional_section   = "\r\n\r\n\t\t" . '// Post loop fields will be added to this section via block middleware. ' . "\r\n\t\t" . '$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
 		} elseif ( $with_middleware && $this->supports_middelware ) {
 			$middleware_method = $this->get_block_config_middleware_method();
 		}
@@ -181,7 +181,7 @@ class Block_Generator extends Generator_Command {
 			$this->supports_middelware ? 'init_data' : 'get_data', // method differs depending on the version of Square one
 			( $with_post_loop_middleware && $this->supports_middelware ) ? "use Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? $this->get_block_model_post_loop_middleware_constructor() : '',
-			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( '			%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n", $this->controller_classname( $component_name ), $class_name ) : ''
+			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( "\r\n\t\t\t" . '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),' . "\r\n\t\t\t", $this->controller_classname( $component_name ), $class_name ) : ''
 		);
 
 		if ( $dry_run ) {

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -114,7 +114,19 @@ class Block_Generator extends Generator_Command {
 			WP_CLI::warning( 'Sorry, this version of Square One does not support block middleware.' );
 		}
 
-		$middleware_use_statement = ( $this->supports_middelware && ( $with_middleware || $with_post_loop_middleware ) ) ? 'use Tribe\Project\Block_Middleware\Contracts\Has_Middleware_Params;' : '';
+		$middleware_use_statement = '';
+
+		if ( $this->supports_middelware ) {
+			if ( $with_middleware || $with_post_loop_middleware ) {
+				$middleware_use_statement = 'use Tribe\Project\Block_Middleware\Contracts\Has_Middleware_Params;';
+			}
+
+			if ( $with_post_loop_middleware ) {
+				$middleware_use_statement .= "\r\n" . 'use Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config;';
+				$middleware_use_statement .= "\r\n" . 'use Tribe\Project\Blocks\Middleware\Post_Loop\Field_Middleware\Post_Loop_Field_Middleware;';
+			}
+		}
+
 		$middleware_interface     = ( $this->supports_middelware && ( $with_middleware || $with_post_loop_middleware ) ) ? ' implements Has_Middleware_Params' : '';
 		$middleware_method        = '';
 		$additional_constants     = '';
@@ -287,18 +299,18 @@ METHOD;
 		return <<<'METHOD'
 		
 	/**
-	 * @TODO Provide specific Post Loop Config and import to use statements.
+	 * @TODO Customize the Post Loop Field Configuration.
 	 *
 	 * @return array<array{post_loop_field_configs: \Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config[]}>
 	 */
 	public function get_middleware_params(): array {
-		$config             = new \Tribe\Project\Blocks\Middleware\Post_Loop\Config\Post_Loop_Field_Config();
+		$config             = new Post_Loop_Field_Config();
 		$config->field_name = self::POST_LIST;
 		$config->group      = $this->get_section_key( self::SECTION_CARDS );
 		
 		return [
 			[
-				\Tribe\Project\Blocks\Middleware\Post_Loop\Field_Middleware\Post_Loop_Field_Middleware::MIDDLEWARE_KEY => [
+				Post_Loop_Field_Middleware::MIDDLEWARE_KEY => [
 					$config,
 				],		
 			],

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -281,7 +281,7 @@ class Block_Generator extends Generator_Command {
 		}
 
 		$definer_path      = $this->src_path . 'Block_Middleware/Block_Middleware_Definer.php';
-		$type_registration = $this->get_post_loop_block_middleware_definition( $class_name );
+		$type_registration = $this->get_post_loop_block_middleware_definition( $class_name ) . PHP_EOL;
 
 		if ( $dry_run ) {
 			WP_CLI::log( '[Dry Run] Skipping registration of block in Block_Middleware_Definer.php ' );
@@ -358,8 +358,7 @@ CONSTRUC;
 				// TODO: use fully qualified class name
 				$class    => [
 					Post_Loop_Field_Middleware::class,
-				],
-				
+				],				
 DEFINITION;
 	}
 }

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -167,7 +167,7 @@ class Block_Generator extends Generator_Command {
 			$this->controller_namespace( $component_name ),
 			$this->controller_classname( $component_name ),
 			$this->supports_middelware ? 'init_data' : 'get_data', // method differs depending on the version of Square one
-			( $with_post_loop_middleware && $this->supports_middelware ) ? "\r\nuse Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
+			( $with_post_loop_middleware && $this->supports_middelware ) ? "use Tribe\Project\Blocks\Middleware\Post_Loop\Post_Loop_Repository;\r\n" : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? $this->get_block_model_post_loop_middleware_constructor() : '',
 			( $with_post_loop_middleware && $this->supports_middelware ) ? sprintf( '%s::POSTS   => $this->post_loop->get_posts( (array) $this->get( %s::POST_LIST ) ),', $this->controller_classname( $component_name ), $class_name ) : ''
 		);

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -134,10 +134,9 @@ class Block_Generator extends Generator_Command {
 			}
 		}
 
-		sort( $use_statements );
-
 		// Prefix use statements with a line break.
 		if ( $use_statements ) {
+			sort( $use_statements );
 			$use_statements = preg_filter( '/^/', "\r\n", $use_statements );
 		}
 

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -243,12 +243,14 @@ class Block_Generator extends Generator_Command {
 	/**
 	 * @TODO Provide specific middleware parameters.
 	 *
-	 * @return string[][]
+	 * @return array<int, array<string, array<int, mixed>>>
 	 */
 	public function get_middleware_params(): array {
 		return [
 			[
-				'the_middleware_key' => 'the_middleware_data',		
+				'the_middleware_key' => [
+					'the_middleware_data',
+				],		
 			],
 		];
 	}

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -352,7 +352,7 @@ CONSTRUC;
 	}
 
 	private function get_post_loop_block_middleware_definition( string $class_name ): string {
-		$class = "\Tribe\Project\Blocks\Types\$class\$class::class";
+		$class = sprintf( '\Tribe\Project\Blocks\Types\%1$s\%1$s::class', $class_name );
 
 		return <<<DEFINITION
 				// TODO: use fully qualified class name

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -123,7 +123,7 @@ class Block_Generator extends Generator_Command {
 		if ( $with_post_loop_middleware && $this->supports_middelware ) {
 			$middleware_method    = $this->get_block_config_post_loop_middleware_method();
 			$additional_constants = "public const SECTION_CARDS = 's-cards';\r\n    public const POST_LIST = 'post_list';\r\n";
-			$additional_section   = "\r\n" . '// Post loop fields will be added to this section via block middleware. ' . "\r\n" . '		$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
+			$additional_section   = "\r\n" . '		// Post loop fields will be added to this section via block middleware. ' . "\r\n" . '		$this->add_section( new Field_Section( self::SECTION_CARDS, esc_html__( \'Cards\', \'tribe\' ), \'accordion\' ) );';
 		} elseif ( $with_middleware && $this->supports_middelware ) {
 			$middleware_method = $this->get_block_config_middleware_method();
 		}

--- a/src/Generators/Block_Generator.php
+++ b/src/Generators/Block_Generator.php
@@ -281,14 +281,12 @@ class Block_Generator extends Generator_Command {
 		}
 
 		$definer_path      = $this->src_path . 'Block_Middleware/Block_Middleware_Definer.php';
-		$type_registration = "\t\t\t\t" . sprintf( 'Types\%1$s\%1$s::class => [
-				Post_Loop_Field_Middleware::class,		
-		],', $class_name ) . "\n";
+		$type_registration = sprintf( '%2$s\Tribe\Project\Blocks\Types\%1$s\%1$s::class => [ %3$s, ], // TODO: use fully qualified class name', $class_name, "\t\t\t\t\t", "\r\n\t\t\t\tPost_Loop_Field_Middleware::class\r\n\t\t\t\t" );
 
 		if ( $dry_run ) {
 			WP_CLI::log( '[Dry Run] Skipping registration of block middleware in Block_Middleware_Definer.php ' );
 		} else {
-			WP_CLI::log( 'Registering block middleware in Block_Middleware_Definer.php ' );
+			WP_CLI::log( 'Registering block in Block_Middleware_Definer.php ' );
 			$this->file_system->insert_into_existing_file( $definer_path, $type_registration, 'self::BLOCK_MIDDLEWARE' );
 		}
 	}

--- a/src/Generators/Component_Generator.php
+++ b/src/Generators/Component_Generator.php
@@ -260,7 +260,7 @@ class Component_Generator extends Generator_Command {
 	}
 
 	private function get_block_controller_middleware_properties(): string {
-		return <<<PROPS
+		return <<<'PROPS'
 		
 	/**
 	 * @var \Tribe\Libs\Field_Models\Models\Post_Proxy[]

--- a/src/Generators/Component_Generator.php
+++ b/src/Generators/Component_Generator.php
@@ -172,7 +172,7 @@ class Component_Generator extends Generator_Command {
 		if ( $with_post_loop_middelware ) {
 			$constants   = "public const POSTS   = 'posts';\r\n";
 			$properties  = $this->get_block_controller_middleware_properties();
-			$assignments = '$this->posts   = (array) $args[ self::POSTS ];';
+			$assignments = "\r\n" . '		$this->posts   = (array) $args[ self::POSTS ];';
 			$defaults    = 'self::POSTS   => [],';
 		}
 
@@ -265,7 +265,8 @@ class Component_Generator extends Generator_Command {
 	/**
 	 * @var \Tribe\Libs\Field_Models\Models\Post_Proxy[]
 	 */
-	private array $posts;		
+	private array $posts;
+			
 PROPS;
 	}
 

--- a/src/Generators/Component_Generator.php
+++ b/src/Generators/Component_Generator.php
@@ -2,9 +2,20 @@
 
 namespace Tribe\Libs\Generators;
 
+use WP_CLI;
 use function WP_CLI\Utils\get_flag_value;
 
 class Component_Generator extends Generator_Command {
+
+	public const ARG_COMPONENT                    = 'component';
+	public const OPTION_TEMPLATE                  = 'template';
+	public const OPTION_CONTROLLER                = 'controller';
+	public const OPTION_CSS                       = 'css';
+	public const OPTION_JS                        = 'js';
+	public const OPTION_DRY_RUN                   = 'dry-run';
+	public const OPTION_WITH_POST_LOOP_MIDDLEWARE = 'with-post-loop-middleware';
+
+
 	/**
 	 * @var string Path to the theme's directory, with a trailing slash
 	 */
@@ -16,55 +27,62 @@ class Component_Generator extends Generator_Command {
 	}
 
 
-	public function description() {
+	public function description(): string {
 		return __( 'Generates a component.', 'tribe' );
 	}
 
-	public function command() {
+	public function command(): string {
 		return 'generate component';
 	}
 
-	public function arguments() {
+	public function arguments(): array {
 		return [
 			[
-				'type'        => 'positional',
-				'name'        => 'component',
+				'type'        => self::ARGUMENT,
+				'name'        => self::ARG_COMPONENT,
 				'optional'    => false,
 				'description' => __( 'The name of the component', 'tribe' ),
 			],
 			[
-				'type'        => 'flag',
-				'name'        => 'template',
+				'type'        => self::FLAG,
+				'name'        => self::OPTION_TEMPLATE,
 				'optional'    => true,
 				'description' => __( 'Whether to generate a placeholder template', 'tribe' ),
 				'default'     => true,
 			],
 			[
-				'type'        => 'flag',
-				'name'        => 'controller',
+				'type'        => self::FLAG,
+				'name'        => self::OPTION_CONTROLLER,
 				'optional'    => true,
 				'description' => __( 'Whether to generate a placeholder Controller class', 'tribe' ),
 				'default'     => true,
 			],
 			[
-				'type'        => 'flag',
-				'name'        => 'css',
+				'type'        => self::FLAG,
+				'name'        => self::OPTION_CSS,
 				'optional'    => true,
 				'description' => __( 'Whether to generate a placeholder css file', 'tribe' ),
 				'default'     => true,
 			],
 			[
-				'type'        => 'flag',
-				'name'        => 'js',
+				'type'        => self::FLAG,
+				'name'        => self::OPTION_JS,
 				'optional'    => true,
 				'description' => __( 'Whether to generate a placeholder js file', 'tribe' ),
 				'default'     => true,
 			],
 			[
-				'type'        => 'flag',
-				'name'        => 'dry-run',
+				'type'        => self::FLAG,
+				'name'        => self::OPTION_JS,
 				'optional'    => true,
 				'description' => __( 'During a dry-run, no files will be written', 'tribe' ),
+				'default'     => false,
+			],
+			[
+				'type'        => self::FLAG,
+				'name'        => self::OPTION_WITH_POST_LOOP_MIDDLEWARE,
+				'optional'    => true,
+				'description' => __( 'Add Post Loop Field middleware to a block controller', 'tribe' ),
 				'default'     => false,
 			],
 		];
@@ -76,18 +94,19 @@ class Component_Generator extends Generator_Command {
 		$path = array_map( 'sanitize_title', explode( '/', $args[0] ) );
 		$name = array_pop( $path );
 
-		$make_template   = get_flag_value( $assoc_args, 'template', true );
-		$make_controller = get_flag_value( $assoc_args, 'controller', true );
-		$make_css        = get_flag_value( $assoc_args, 'css', true );
-		$make_js         = get_flag_value( $assoc_args, 'js', true );
-		$dry_run         = get_flag_value( $assoc_args, 'dry-run', false );
+		$make_template             = get_flag_value( $assoc_args, self::OPTION_TEMPLATE, true );
+		$make_controller           = get_flag_value( $assoc_args, self::OPTION_CONTROLLER, true );
+		$make_css                  = get_flag_value( $assoc_args, self::OPTION_CSS, true );
+		$make_js                   = get_flag_value( $assoc_args, self::OPTION_JS, true );
+		$dry_run                   = get_flag_value( $assoc_args, self::OPTION_DRY_RUN, false );
+		$with_post_loop_middleware = get_flag_value( $assoc_args, self::OPTION_WITH_POST_LOOP_MIDDLEWARE, false );
 
 		if ( $make_template ) {
 			$this->make_template( $name, $path, $dry_run );
 		}
 
 		if ( $make_controller ) {
-			$this->make_controller( $name, $path, $dry_run );
+			$this->make_controller( $name, $path, $with_post_loop_middleware, $dry_run );
 		}
 
 		if ( $make_css ) {
@@ -98,7 +117,7 @@ class Component_Generator extends Generator_Command {
 			$this->make_js( $name, $path, $dry_run );
 		}
 
-		\WP_CLI::success( 'Way to go! ' . \WP_CLI::colorize( "%W{$name}%n" ) . ' component has been created' );
+		WP_CLI::success( 'Way to go! ' . WP_CLI::colorize( "%W{$name}%n" ) . ' component has been created' );
 	}
 
 	private function component_directory( array $path, $name ): string {
@@ -124,7 +143,7 @@ class Component_Generator extends Generator_Command {
 		$template_file    = $directory . $name . '.php';
 		$namespace        = $this->controller_namespace( $path, $name );
 		$class_name       = $this->controller_classname( $name );
-		
+
 		$template_contents = sprintf(
 			file_get_contents( __DIR__ . '/templates/component/template.php.tmpl' ),
 			$namespace,
@@ -133,32 +152,47 @@ class Component_Generator extends Generator_Command {
 
 
 		if ( $dry_run ) {
-			\WP_CLI::log( '[Dry Run] Template file: ' . $template_file );
-			\WP_CLI::log( 'Template contents: ' . "\n" . $template_contents );
+			WP_CLI::log( '[Dry Run] Template file: ' . $template_file );
+			WP_CLI::log( 'Template contents: ' . "\n" . $template_contents );
 		} else {
-			\WP_CLI::log( 'Writing template file to ' . $template_file );
+			WP_CLI::log( 'Writing template file to ' . $template_file );
 			$this->file_system->create_directory( $directory );
 			$this->file_system->write_file( $template_file, $template_contents );
 		}
 	}
 
-	private function make_controller( $name, $path, $dry_run ): void {
-		$classname = $this->controller_classname( $name );
-		$namespace = $this->controller_namespace( $path, $name );
+	private function make_controller( $name, $path, $with_post_loop_middelware, $dry_run ): void {
+		$classname   = $this->controller_classname( $name );
+		$namespace   = $this->controller_namespace( $path, $name );
+		$constants   = '';
+		$properties  = '';
+		$assignments = '';
+		$defaults    = '';
+
+		if ( $with_post_loop_middelware ) {
+			$constants   = "public const POSTS = 'posts';\r\n";
+			$properties  = $this->get_block_controller_middleware_properties();
+			$assignments = '$this->posts   = (array) $args[ self::POSTS ];';
+			$defaults    = 'self::POSTS   => [],';
+		}
 
 		$directory           = $this->component_directory( $path, $name );
 		$controller_file     = $directory . $classname . '.php';
 		$controller_contents = sprintf(
 			file_get_contents( __DIR__ . '/templates/component/controller.php.tmpl' ),
 			$classname,
-			$namespace
+			$namespace,
+			$constants,
+			$properties,
+			$assignments,
+			$defaults
 		);
 
 		if ( $dry_run ) {
-			\WP_CLI::log( '[Dry Run] Controller file: ' . $controller_file );
-			\WP_CLI::log( 'Controller contents: ' . "\n" . $controller_contents );
+			WP_CLI::log( '[Dry Run] Controller file: ' . $controller_file );
+			WP_CLI::log( 'Controller contents: ' . "\n" . $controller_contents );
 		} else {
-			\WP_CLI::log( 'Writing controller file to ' . $controller_file );
+			WP_CLI::log( 'Writing controller file to ' . $controller_file );
 			$this->file_system->create_directory( $directory );
 			$this->file_system->write_file( $controller_file, $controller_contents );
 		}
@@ -180,15 +214,15 @@ class Component_Generator extends Generator_Command {
 			$human_name
 		);
 		if ( $dry_run ) {
-			\WP_CLI::log( '[Dry Run] CSS index file: ' . $index_file );
-			\WP_CLI::log( 'CSS index contents: ' . "\n" . $index_contents );
-			\WP_CLI::log( '[Dry Run] CSS source file: ' . $source_file );
-			\WP_CLI::log( 'CSS source contents: ' . "\n" . $source_contents );
+			WP_CLI::log( '[Dry Run] CSS index file: ' . $index_file );
+			WP_CLI::log( 'CSS index contents: ' . "\n" . $index_contents );
+			WP_CLI::log( '[Dry Run] CSS source file: ' . $source_file );
+			WP_CLI::log( 'CSS source contents: ' . "\n" . $source_contents );
 		} else {
-			\WP_CLI::log( 'Writing CSS index file to ' . $index_file );
+			WP_CLI::log( 'Writing CSS index file to ' . $index_file );
 			$this->file_system->create_directory( $directory );
 			$this->file_system->write_file( $index_file, $index_contents );
-			\WP_CLI::log( 'Writing CSS source file to ' . $source_file );
+			WP_CLI::log( 'Writing CSS source file to ' . $source_file );
 			$this->file_system->create_directory( $directory . 'css/' );
 			$this->file_system->write_file( $source_file, $source_contents );
 		}
@@ -211,18 +245,28 @@ class Component_Generator extends Generator_Command {
 		);
 
 		if ( $dry_run ) {
-			\WP_CLI::log( '[Dry Run] JS index file: ' . $index_file );
-			\WP_CLI::log( 'JS index contents: ' . "\n" . $index_contents );
-			\WP_CLI::log( '[Dry Run] JS source file: ' . $source_file );
-			\WP_CLI::log( 'JS source contents: ' . "\n" . $source_contents );
+			WP_CLI::log( '[Dry Run] JS index file: ' . $index_file );
+			WP_CLI::log( 'JS index contents: ' . "\n" . $index_contents );
+			WP_CLI::log( '[Dry Run] JS source file: ' . $source_file );
+			WP_CLI::log( 'JS source contents: ' . "\n" . $source_contents );
 		} else {
-			\WP_CLI::log( 'Writing JS index file to ' . $index_file );
+			WP_CLI::log( 'Writing JS index file to ' . $index_file );
 			$this->file_system->create_directory( $directory );
 			$this->file_system->write_file( $index_file, $index_contents );
-			\WP_CLI::log( 'Writing JS source file to ' . $source_file );
+			WP_CLI::log( 'Writing JS source file to ' . $source_file );
 			$this->file_system->create_directory( $directory . 'js/' );
 			$this->file_system->write_file( $source_file, $source_contents );
 		}
+	}
+
+	private function get_block_controller_middleware_properties(): string {
+		return <<<PROPS
+		
+	/**
+	 * @var \Tribe\Libs\Field_Models\Models\Post_Proxy[]
+	 */
+	private array $posts;		
+PROPS;
 	}
 
 	protected function class_name( string $component_name ): string {

--- a/src/Generators/Component_Generator.php
+++ b/src/Generators/Component_Generator.php
@@ -170,7 +170,7 @@ class Component_Generator extends Generator_Command {
 		$defaults    = '';
 
 		if ( $with_post_loop_middelware ) {
-			$constants   = "public const POSTS = 'posts';\r\n";
+			$constants   = "public const POSTS   = 'posts';\r\n";
 			$properties  = $this->get_block_controller_middleware_properties();
 			$assignments = '$this->posts   = (array) $args[ self::POSTS ];';
 			$defaults    = 'self::POSTS   => [],';

--- a/src/Generators/README.md
+++ b/src/Generators/README.md
@@ -115,6 +115,12 @@ the `image_gallery` component.
 
 The `--dry-run` flag will show you the files the command would create, without writing to the file system.
 
+Example with Post Loop Field Middleware:
+
+```
+wp s1 generate block image-gallery --with-post-loop-field-middleware
+```
+
 # Settings Page Generator
 
 TODO: write documentation for the settings page generator

--- a/src/Generators/templates/block/config.php.tmpl
+++ b/src/Generators/templates/block/config.php.tmpl
@@ -17,7 +17,7 @@ class %1$s extends Block_Config%5$s {
 
 	public const TITLE       = 'title';
 	public const DESCRIPTION = 'description';
-
+	%7$s
 	public function add_block(): void {
 		$this->set_block( new Block( self::NAME, [
 			'title'       => esc_html__( '%3$s', 'tribe' ),

--- a/src/Generators/templates/block/config.php.tmpl
+++ b/src/Generators/templates/block/config.php.tmpl
@@ -6,7 +6,7 @@ use Tribe\Libs\ACF\Block;
 use Tribe\Libs\ACF\Block_Config;
 use Tribe\Libs\ACF\Field;
 use Tribe\Libs\ACF\Field_Section;
-%4$s;
+%4$s
 
 class %1$s extends Block_Config%5$s {
 

--- a/src/Generators/templates/block/config.php.tmpl
+++ b/src/Generators/templates/block/config.php.tmpl
@@ -5,8 +5,7 @@ namespace Tribe\Project\Blocks\Types\%1$s;
 use Tribe\Libs\ACF\Block;
 use Tribe\Libs\ACF\Block_Config;
 use Tribe\Libs\ACF\Field;
-use Tribe\Libs\ACF\Field_Section;
-%4$s
+use Tribe\Libs\ACF\Field_Section;%4$s
 
 class %1$s extends Block_Config%5$s {
 
@@ -55,8 +54,7 @@ class %1$s extends Block_Config%5$s {
 			);
 
 		// Setting Fields
-		$this->add_section( new Field_Section( self::SECTION_SETTINGS, esc_html__( 'Settings', 'tribe' ), 'accordion' ) );
-		%8$s
+		$this->add_section( new Field_Section( self::SECTION_SETTINGS, esc_html__( 'Settings', 'tribe' ), 'accordion' ) );%8$s
 	}
 	%6$s
 }

--- a/src/Generators/templates/block/config.php.tmpl
+++ b/src/Generators/templates/block/config.php.tmpl
@@ -56,6 +56,7 @@ class %1$s extends Block_Config%5$s {
 
 		// Setting Fields
 		$this->add_section( new Field_Section( self::SECTION_SETTINGS, esc_html__( 'Settings', 'tribe' ), 'accordion' ) );
+		%8$s
 	}
 	%6$s
 }

--- a/src/Generators/templates/block/model.php.tmpl
+++ b/src/Generators/templates/block/model.php.tmpl
@@ -17,8 +17,7 @@ class %1$s_Model extends Base_Model {
 		return [
 			%3$s::ATTRS   => $this->get_attrs(),
 			%3$s::CLASSES => $this->get_classes(),
-			%7$s
-			// TODO: map values from the block to the controller
+			%7$s// TODO: map values from the block to the controller
 		];
 	}
 

--- a/src/Generators/templates/block/model.php.tmpl
+++ b/src/Generators/templates/block/model.php.tmpl
@@ -3,7 +3,7 @@
 namespace Tribe\Project\Blocks\Types\%1$s;
 
 use Tribe\Project\Blocks\Types\Base_Model;
-use %2$s\%3$s;
+%5$suse %2$s\%3$s;
 
 /**
  * Class %1$s_Model
@@ -12,11 +12,12 @@ use %2$s\%3$s;
  * for the component.
  */
 class %1$s_Model extends Base_Model {
-
+	%6$s
 	public function %4$s(): array {
 		return [
 			%3$s::ATTRS   => $this->get_attrs(),
 			%3$s::CLASSES => $this->get_classes(),
+			%7$s
 			// TODO: map values from the block to the controller
 		];
 	}

--- a/src/Generators/templates/block/model.php.tmpl
+++ b/src/Generators/templates/block/model.php.tmpl
@@ -14,10 +14,10 @@ use %2$s\%3$s;
 class %1$s_Model extends Base_Model {
 	%6$s
 	public function %4$s(): array {
+		// TODO: map values from the block to the controller
 		return [
 			%3$s::ATTRS   => $this->get_attrs(),
 			%3$s::CLASSES => $this->get_classes(),%7$s
-			// TODO: map values from the block to the controller
 		];
 	}
 

--- a/src/Generators/templates/block/model.php.tmpl
+++ b/src/Generators/templates/block/model.php.tmpl
@@ -16,8 +16,8 @@ class %1$s_Model extends Base_Model {
 	public function %4$s(): array {
 		return [
 			%3$s::ATTRS   => $this->get_attrs(),
-			%3$s::CLASSES => $this->get_classes(),
-			%7$s// TODO: map values from the block to the controller
+			%3$s::CLASSES => $this->get_classes(),%7$s
+			// TODO: map values from the block to the controller
 		];
 	}
 

--- a/src/Generators/templates/block/model.php.tmpl
+++ b/src/Generators/templates/block/model.php.tmpl
@@ -2,8 +2,8 @@
 
 namespace Tribe\Project\Blocks\Types\%1$s;
 
-use Tribe\Project\Blocks\Types\Base_Model;
-%5$suse %2$s\%3$s;
+%5$suse Tribe\Project\Blocks\Types\Base_Model;
+use %2$s\%3$s;
 
 /**
  * Class %1$s_Model

--- a/src/Generators/templates/component/controller.php.tmpl
+++ b/src/Generators/templates/component/controller.php.tmpl
@@ -20,13 +20,11 @@ class %1$s extends Abstract_Controller {
 	 */
 	private array $classes;
 	%4$s
-
 	public function __construct( array $args = [] ) {
 		$args = $this->parse_args( $args );
 
 		$this->attrs   = (array) $args[ self::ATTRS ];
-		$this->classes = (array) $args[ self::CLASSES ];
-		%5$s
+		$this->classes = (array) $args[ self::CLASSES ];%5$s
 	}
 
 	public function get_attributes(): string {

--- a/src/Generators/templates/component/controller.php.tmpl
+++ b/src/Generators/templates/component/controller.php.tmpl
@@ -9,7 +9,7 @@ class %1$s extends Abstract_Controller {
 
 	public const ATTRS   = 'attrs';
 	public const CLASSES = 'classes';
-
+	%3$s
 	/**
 	 * @var string[]
 	 */
@@ -19,12 +19,14 @@ class %1$s extends Abstract_Controller {
 	 * @var string[]
 	 */
 	private array $classes;
+	%4$s
 
 	public function __construct( array $args = [] ) {
 		$args = $this->parse_args( $args );
 
 		$this->attrs   = (array) $args[ self::ATTRS ];
 		$this->classes = (array) $args[ self::CLASSES ];
+		%5$s
 	}
 
 	public function get_attributes(): string {
@@ -39,6 +41,7 @@ class %1$s extends Abstract_Controller {
 		return [
 			self::ATTRS   => [],
 			self::CLASSES => [],
+			%6$s
 		];
 	}
 


### PR DESCRIPTION
### What's Changed

With the refactor of how we now manually add the Post Loop Field to the Block model, this update adds support for that in addition to changing the default model middleware generation to support the proper syntax.

- Added: `wp s1 generate block <name> --with-post-loop-middleware` that gives a base configuration for a block with Post Loop Middleware.
- Changed: The `Block_Config` class now uses the `With_Field_Prefix` out of the box so those methods are available to all blocks when needed.
- Changed: `Block_Config`'s generated with the block generator now use `\Tribe\Project\Blocks\Block_Category::CUSTOM_BLOCK_CATEGORY_SLUG` if the project has it available, otherwise it uses the `text` category.

### QA

Pull the branch from https://github.com/moderntribe/square-one/pull/1014 and try to make a block, e.g. with `SO`: `so wp -- s1 generate block My_Test_Block --with-post-loop-middleware`

### Known Issues

- Block Config with `--with-post-loop-middleware` constants can't be properly lined up, so will fail PHPCS, so the developer just has to run the phpcbf on that file.
