### PR TITLE
Feature: Basic PHP 8 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '7.3', '7.4' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
         wordpress-version: [ 'latest', '5.3.2' ]
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
         wordpress-version: [ 'latest', '5.3.2' ]
+        exclude:
+          - php-versions: '8.0'
+            wordpress-version: '5.3.2'
+          - php-versions: '8.1'
+            wordpress-version: '5.3.2'
       fail-fast: false
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Updated: Allow composer installs on any PHP version `>=7.2` to allow installation on PHP 8.x projects.
 
 ## 3.6.0 - 2022-08-09
 - Added: `wp s1 generate block <name> --with-post-loop-middleware` that gives a base configuration for a block with Post Loop Middleware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 - Updated: Allow composer installs on any PHP version `>=7.2` to allow installation on PHP 8.x projects.
+- Updated: Use forked version of https://github.com/moderntribe/monolog-wp-cli to allow `>=7.2` installs.
 
 ## 3.6.0 - 2022-08-09
 - Added: `wp s1 generate block <name> --with-post-loop-middleware` that gives a base configuration for a block with Post Loop Middleware.

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/bordoni/phpass"
+        },
+        {
+          "type": "vcs",
+          "url": "https://github.com/moderntribe/monolog-wp-cli"
         }
     ],
     "require": {
@@ -17,7 +21,7 @@
         "composer-plugin-api": "^1.0 || ^2.0",
         "enshrined/svg-sanitize": "^0.15.4",
         "filp/whoops": "^2.2@dev",
-        "mhcg/monolog-wp-cli": "^1.0",
+        "mhcg/monolog-wp-cli": "^1.1",
         "monolog/monolog": "^2.0",
         "php-di/php-di": "^6.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "composer-plugin-api": "^1.0 || ^2.0",
         "enshrined/svg-sanitize": "^0.15.4",
         "filp/whoops": "^2.2@dev",
-        "mhcg/monolog-wp-cli": "^1.1",
+        "mhcg/monolog-wp-cli": "dev-master as 1.2.0",
         "monolog/monolog": "^2.0",
         "php-di/php-di": "^6.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "composer-plugin-api": "^1.0 || ^2.0",
         "enshrined/svg-sanitize": "^0.15.4",
         "filp/whoops": "^2.2@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8a19eff60cc1bdffdd1a5274e9e9229",
+    "content-hash": "9277a13351fa6e2a7f1ec92dd14bb7dc",
     "packages": [
         {
             "name": "enshrined/svg-sanitize",
@@ -124,21 +124,21 @@
         },
         {
             "name": "mhcg/monolog-wp-cli",
-            "version": "v1.1.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mhcg/monolog-wp-cli.git",
-                "reference": "33cd515fa7e5eac2ebca8aac995aa97a4ab2b77b"
+                "url": "https://github.com/moderntribe/monolog-wp-cli.git",
+                "reference": "fdf6fafe86bae3e58fbdb77fd1827f6798762c15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mhcg/monolog-wp-cli/zipball/33cd515fa7e5eac2ebca8aac995aa97a4ab2b77b",
-                "reference": "33cd515fa7e5eac2ebca8aac995aa97a4ab2b77b",
+                "url": "https://api.github.com/repos/moderntribe/monolog-wp-cli/zipball/fdf6fafe86bae3e58fbdb77fd1827f6798762c15",
+                "reference": "fdf6fafe86bae3e58fbdb77fd1827f6798762c15",
                 "shasum": ""
             },
             "require": {
                 "monolog/monolog": "^2.0",
-                "php": "^7.2"
+                "php": ">=7.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "8.5.* || 9.0.*",
@@ -151,7 +151,11 @@
                     "MHCG\\Monolog\\": "src/Monolog"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "MHCGDev\\Monolog\\": "tests/Monolog"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -171,10 +175,10 @@
             ],
             "support": {
                 "issues": "https://github.com/mhcg/monolog-wp-cli/issues",
-                "source": "https://github.com/mhcg/monolog-wp-cli",
-                "wiki": "https://github.com/mhcg/monolog-wp-cli/wiki"
+                "wiki": "https://github.com/mhcg/monolog-wp-cli/wiki",
+                "source": "https://github.com/mhcg/monolog-wp-cli"
             },
-            "time": "2020-03-23T20:17:57+00:00"
+            "time": "2022-08-10T20:06:45+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e1d54559e8beeafdbf4d535f61c5cfd",
+    "content-hash": "e8a19eff60cc1bdffdd1a5274e9e9229",
     "packages": [
         {
             "name": "enshrined/svg-sanitize",
@@ -2934,16 +2934,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.60.0",
+            "version": "2.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "00a259ae02b003c563158b54fb6743252b638ea6"
+                "reference": "bdf4f4fe3a3eac4de84dbec0738082a862c68ba6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/00a259ae02b003c563158b54fb6743252b638ea6",
-                "reference": "00a259ae02b003c563158b54fb6743252b638ea6",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/bdf4f4fe3a3eac4de84dbec0738082a862c68ba6",
+                "reference": "bdf4f4fe3a3eac4de84dbec0738082a862c68ba6",
                 "shasum": ""
             },
             "require": {
@@ -3032,7 +3032,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-27T15:57:48+00:00"
+            "time": "2022-08-06T12:41:24+00:00"
         },
         {
             "name": "nette/finder",
@@ -8460,7 +8460,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "platform-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9277a13351fa6e2a7f1ec92dd14bb7dc",
+    "content-hash": "f2aee5b123733e1a5c8a7b33efd5bfdc",
     "packages": [
         {
             "name": "enshrined/svg-sanitize",
@@ -124,7 +124,7 @@
         },
         {
             "name": "mhcg/monolog-wp-cli",
-            "version": "1.1.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moderntribe/monolog-wp-cli.git",
@@ -145,6 +145,7 @@
                 "squizlabs/php_codesniffer": "^3.5",
                 "wp-cli/wp-cli": "^2.0"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -8456,10 +8457,18 @@
             "time": "2021-07-11T04:52:41+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "mhcg/monolog-wp-cli",
+            "version": "9999999-dev",
+            "alias": "1.2.0",
+            "alias_normalized": "1.2.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "filp/whoops": 20
+        "filp/whoops": 20,
+        "mhcg/monolog-wp-cli": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/src/ACF/composer.json
+++ b/src/ACF/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-object-meta": "^3.7"
     },
     "autoload": {

--- a/src/Assets/composer.json
+++ b/src/Assets/composer.json
@@ -8,8 +8,8 @@
         "preferred-install": "dist"
     },
     "require": {
-        "moderntribe/square1-container": "^3.7",
-        "php": "^7.2"
+        "php": ">=7.2",
+        "moderntribe/square1-container": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/Blog_Copier/composer.json
+++ b/src/Blog_Copier/composer.json
@@ -9,9 +9,9 @@
     },
     "minimum-stability": "dev",
     "require": {
+        "php": ">=7.2",
         "moderntribe/square1-container": "^3.7",
-        "moderntribe/square1-queues": "^3.7",
-        "php": "^7.2"
+        "moderntribe/square1-queues": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/CLI/composer.json
+++ b/src/CLI/composer.json
@@ -9,7 +9,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-container": "^3.7"
     },
     "autoload": {

--- a/src/Cache/composer.json
+++ b/src/Cache/composer.json
@@ -8,9 +8,9 @@
         "preferred-install": "dist"
     },
     "require": {
+        "php": ">=7.2",
         "moderntribe/square1-cli": "^3.7",
-        "moderntribe/square1-container": "^3.7",
-        "php": "^7.2"
+        "moderntribe/square1-container": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/Container/composer.json
+++ b/src/Container/composer.json
@@ -9,7 +9,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "php-di/php-di": "^6.0"
     },
     "autoload": {

--- a/src/Generators/composer.json
+++ b/src/Generators/composer.json
@@ -8,9 +8,9 @@
         "preferred-install": "dist"
     },
     "require": {
+        "php": ">=7.2",
         "moderntribe/square1-cli": "^3.7",
-        "moderntribe/square1-container": "^3.7",
-        "php": "^7.2"
+        "moderntribe/square1-container": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "moderntribe/square1-container": "^3.7",
         "monolog/monolog": "^2.0",

--- a/src/Media/composer.json
+++ b/src/Media/composer.json
@@ -9,7 +9,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "enshrined/svg-sanitize": "^0.13.3",
         "moderntribe/square1-container": "^3.7"
     },

--- a/src/Nav/composer.json
+++ b/src/Nav/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2"
+        "php": ">=7.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Object_Meta/composer.json
+++ b/src/Object_Meta/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-container": "^3.7"
     },
     "autoload": {

--- a/src/Oembed/composer.json
+++ b/src/Oembed/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-cache": "^3.7"
     },
     "autoload": {

--- a/src/P2P/composer.json
+++ b/src/P2P/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-container": "^3.7"
     },
     "autoload": {

--- a/src/Pipeline/composer.json
+++ b/src/Pipeline/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-container": "^3.7"
     },
     "autoload": {

--- a/src/Post_Meta/composer.json
+++ b/src/Post_Meta/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-object-meta": "^3.7"
     },
     "autoload": {

--- a/src/Post_Type/composer.json
+++ b/src/Post_Type/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-object-meta": "^3.7"
     },
     "autoload": {

--- a/src/Queues/composer.json
+++ b/src/Queues/composer.json
@@ -9,9 +9,9 @@
     },
     "minimum-stability": "dev",
     "require": {
+        "php": ">=7.2",
         "moderntribe/square1-cli": "^3.7",
-        "moderntribe/square1-container": "^3.7",
-        "php": "^7.2"
+        "moderntribe/square1-container": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/Queues_Mysql/composer.json
+++ b/src/Queues_Mysql/composer.json
@@ -9,10 +9,10 @@
     },
     "minimum-stability": "dev",
     "require": {
+        "php": ">=7.2",
         "moderntribe/square1-cli": "^3.7",
         "moderntribe/square1-container": "^3.7",
-        "moderntribe/square1-queues": "^3.7",
-        "php": "^7.2"
+        "moderntribe/square1-queues": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/Request/composer.json
+++ b/src/Request/composer.json
@@ -9,7 +9,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2"
+        "php": ">=7.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Required_Page/composer.json
+++ b/src/Required_Page/composer.json
@@ -9,8 +9,8 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "moderntribe/square1-container": "^3.7",
-        "php": "^7.2"
+        "php": ">=7.2",
+        "moderntribe/square1-container": "^3.7"
     },
     "suggest": {
         "moderntribe/square1-acf": "Supports automatic registration of options to manage the assigned pages"

--- a/src/Routes/composer.json
+++ b/src/Routes/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-container": "^3.7"
     },
     "autoload": {

--- a/src/Schema/composer.json
+++ b/src/Schema/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2"
+        "php": ">=7.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Settings/composer.json
+++ b/src/Settings/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2"
+        "php": ">=7.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Taxonomy/composer.json
+++ b/src/Taxonomy/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-object-meta": "^3.7"
     },
     "autoload": {

--- a/src/Twig/composer.json
+++ b/src/Twig/composer.json
@@ -9,7 +9,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "twig/twig": "^3.0"
     },
     "autoload": {

--- a/src/User/composer.json
+++ b/src/User/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "moderntribe/square1-object-meta": "^3.7"
     },
     "autoload": {

--- a/src/Utils/composer.json
+++ b/src/Utils/composer.json
@@ -8,7 +8,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": "^7.2"
+        "php": ">=7.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Whoops/composer.json
+++ b/src/Whoops/composer.json
@@ -9,7 +9,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "filp/whoops": "^2.2@dev",
         "moderntribe/square1-container": "^3.7"
     },


### PR DESCRIPTION
Right now, this can't even be installed on a project who's minimum requirement is PHP 8.0, this should allow that to happen while still locking packages in the PHP7.2 version, so it's not 100% guaranteed to work until we've completed full migrations.

However, this will at least allow it to be installed and tested on future PHP 8.x+ minimum requirements.

~I'm going to test this to see what version this will come out as, as I don't think there are any backwards compatible issues at the moment, so it could even be considered a bug fix.~

Edit: Working just fine on our 7.4 systems, some deps don't work for PHP8.0 projects yet, but we'll address that down the road.