### PR TITLE
BUGFIX: Use correct class for Taxonomy_Subscriber $config_class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Bugfix: Use correct class-string docblock for Taxonomy_Subscriber.
 
 ## 4.0.3 - 2022-08-17
-
-## 4.0.0 - 2022-08-17
 - Changed: Create the `4.x` branch/major version, which has a minimum version of `PHP7.4` for use with **legacy PHP7.4 Square One projects where their hosts will be force upgrading to PHP8.0**. This is intermediate release to allow an ease of upgrading, however new projects should use the upcoming `5.x` releases which will be optimized for PHP8.0+.
 - Changed: `composer.lock` has been removed to be more in line with other monorepo libraries and to allow more flexible versions of packages to be installed when using Tribe Libs in the Square One framework.
 - Changed: Force `phpcompatibility/php-compatibility` to a development version to prevent PHPCS errors when using PHP8.0+.
 - Added: New repo: [Square1 Field Models](https://github.com/moderntribe/square1-field-models) now that we are on PHP7.4+
 - Added: New repo: [Square1 WP Downloader](https://github.com/moderntribe/square1-wp-downloader) that adds a CLI tool to download WordPress and plugins for automated testing purposes.
 - Added: `composer test:setup` to automate downloading test dependencies, `composer test:integration` to run integration tests.
+
 
 ## 3.6.0 - 2022-08-09
 - Added: `wp s1 generate block <name> --with-post-loop-middleware` that gives a base configuration for a block with Post Loop Middleware.

--- a/src/Taxonomy/Taxonomy_Subscriber.php
+++ b/src/Taxonomy/Taxonomy_Subscriber.php
@@ -7,7 +7,7 @@ use Tribe\Libs\Container\Abstract_Subscriber;
 abstract class Taxonomy_Subscriber extends Abstract_Subscriber {
 
 	/**
-	 * @var class-string<\Tribe\Libs\Taxonomy\Term_Object> The taxonomy configuration class. Should extend Taxonomy_Config
+	 * @var class-string<\Tribe\Libs\Taxonomy\Taxonomy_Config> The taxonomy configuration class. Should extend Taxonomy_Config
 	 */
 	protected $config_class;
 


### PR DESCRIPTION
- Bugfix: phpstan: Property Tribe\Project\Taxonomies\Example\Subscriber::$config_class (class-string<Tribe\Libs\Taxonomy\Term_Object>) does not accept default value of type string.