### PR TITLE
[4.x] Replace YouTube oEmbeds with the youtube-nocookie.com domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- Added: All YouTube oEmbeds will use youtube-nocookie.com, but can be disabled in your project with `define( 'TRIBE_DISABLE_YOUTUBE_NO_COOKIE', false )` in your wp-config.php.
+- Added: All YouTube oEmbeds will use youtube-nocookie.com, but can be disabled in your project with `define( 'TRIBE_ENABLE_YOUTUBE_NOCOOKIE_URI', false )` in your wp-config.php.
 
 ## 4.0.16 - 2022-08-21
 - Fixed: splitting packages into existing, specific branches in monorepo.yml using a forked action https://github.com/moderntribe/monorepo-split-github-action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added: All YouTube oEmbeds will use youtube-nocookie.com, but can be disabled in your project with `define( 'TRIBE_DISABLE_YOUTUBE_NO_COOKIE', false )` in your wp-config.php.
 
 ## 4.0.16 - 2022-08-21
 - Fixed: splitting packages into existing, specific branches in monorepo.yml using a forked action https://github.com/moderntribe/monorepo-split-github-action

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,8 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
+        "ext-simplexml": "*",
+        "ext-zlib": "*",
         "composer-plugin-api": "^1.0 || ^2.0",
         "enshrined/svg-sanitize": "^0.15",
         "filp/whoops": "^2.2@dev",

--- a/src/Media/Media_Subscriber.php
+++ b/src/Media/Media_Subscriber.php
@@ -69,7 +69,7 @@ class Media_Subscriber extends Abstract_Subscriber {
 	}
 
 	private function oembed(): void {
-		if ( defined( 'TRIBE_DISABLE_YOUTUBE_NO_COOKIE' ) && TRIBE_DISABLE_YOUTUBE_NO_COOKIE === false ) {
+		if ( defined( 'TRIBE_ENABLE_YOUTUBE_NOCOOKIE_URI' ) && TRIBE_ENABLE_YOUTUBE_NOCOOKIE_URI === false ) {
 			return;
 		}
 

--- a/src/Media/Media_Subscriber.php
+++ b/src/Media/Media_Subscriber.php
@@ -1,18 +1,20 @@
-<?php
-declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\Media;
 
 use Tribe\Libs\Container\Abstract_Subscriber;
+use Tribe\Libs\Media\Oembed\YouTube_Oembed_Filter;
 use Tribe\Libs\Media\Svg\Enable_Uploads;
 use Tribe\Libs\Media\Svg\Sanitize_Uploads;
 use Tribe\Libs\Media\Svg\Set_Attachment_Metadata;
 
 class Media_Subscriber extends Abstract_Subscriber {
+
 	public function register(): void {
 		$this->full_size_gif();
 		$this->svg_uploads();
 		$this->disable_responsive_images();
+		$this->oembed();
 	}
 
 	private function full_size_gif(): void {
@@ -65,4 +67,19 @@ class Media_Subscriber extends Abstract_Subscriber {
 			$this->container->get( WP_Responsive_Image_Disabler::class )->disable_wordpress_filters();
 		}, 10, 0 );
 	}
+
+	private function oembed(): void {
+		if ( defined( 'TRIBE_DISABLE_YOUTUBE_NO_COOKIE' ) && TRIBE_DISABLE_YOUTUBE_NO_COOKIE === false ) {
+			return;
+		}
+
+		add_filter(
+			'oembed_dataparse',
+			fn ( $html ) =>
+			$this->container->get( YouTube_Oembed_Filter::class )->force_youtube_no_cookie_embed( (string) $html ),
+			999,
+			1
+		);
+	}
+
 }

--- a/src/Media/Oembed/YouTube_Oembed_Filter.php
+++ b/src/Media/Oembed/YouTube_Oembed_Filter.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Oembed;
+
+class YouTube_Oembed_Filter {
+
+	/**
+	 * Replace all youtube.com/embed URI's with youtube-nocookie.com/embed URI's.
+	 *
+	 * @filter oembed_dataparse
+	 *
+	 * @param string $html The returned oEmbed HTML, generally an iframe.
+	 */
+	public function force_youtube_no_cookie_embed( string $html ): string {
+		return str_ireplace( 'youtube.com/embed', 'youtube-nocookie.com/embed', $html );
+	}
+
+}

--- a/src/Media/composer.json
+++ b/src/Media/composer.json
@@ -10,6 +10,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.4",
+        "ext-zlib": "*",
+        "ext-simplexml": "*",
         "enshrined/svg-sanitize": "^0.15",
         "moderntribe/square1-container": "^4.1"
     },

--- a/src/Taxonomy/Taxonomy_Registration.php
+++ b/src/Taxonomy/Taxonomy_Registration.php
@@ -109,15 +109,20 @@ class Taxonomy_Registration {
 	/**
 	 * TODO: move this to a taxonomy repository class
 	 *
-	 * @param string     $taxonomy
-	 * @param string     $key_property
-	 * @param string     $value_property
-	 * @param array|null $args
+	 * @param  string  $taxonomy
+	 * @param  string  $key_property
+	 * @param  string  $value_property
+	 * @param  array   $args
+	 *
 	 * @return array
 	 */
-	public static function get_taxonomy_list( $taxonomy, $key_property = 'term_id', $value_property = 'name', array $args = null ) {
-		$terms = get_terms( $taxonomy, $args );
-		$list = [ ];
+	public static function get_taxonomy_list( $taxonomy, $key_property = 'term_id', $value_property = 'name', array $args = [] ) {
+		$args = array_merge( [
+			'taxonomy' => $taxonomy,
+		], $args );
+
+		$terms = get_terms( $args );
+		$list  = [];
 
 		foreach ( $terms as $term ) {
 			$list[ $term->$key_property ] = $term->$value_property;
@@ -125,4 +130,5 @@ class Taxonomy_Registration {
 
 		return $list;
 	}
+
 }

--- a/tests/integration/Tribe/Libs/Media/Oembed/YouTubeNoCookieReplacementTest.php
+++ b/tests/integration/Tribe/Libs/Media/Oembed/YouTubeNoCookieReplacementTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Oembed;
+
+use Tribe\Libs\Tests\Test_Case;
+
+final class YouTubeNoCookieReplacementTest extends Test_Case {
+
+	private YouTube_Oembed_Filter $youtube_filter;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->youtube_filter = new YouTube_Oembed_Filter();
+	}
+
+	protected function tearDown(): void {
+		remove_all_filters( 'oembed_dataparse' );
+
+		// @phpstan-ignore-next-line
+		parent::tearDown();
+	}
+
+	public function test_it_replaces_youtube_embeds_with_no_cookie_domain(): void {
+		$input          = '<iframe width="560" height="315" src="https://www.youtube.com/embed/TcWPiHjIExA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>';
+		$expected       = '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/TcWPiHjIExA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>';
+
+		$this->assertSame( $expected, $this->youtube_filter->force_youtube_no_cookie_embed( $input ) );
+	}
+
+	public function test_it_replaces_youtube_embeds_with_no_cookie_domain_using_camel_case_domain(): void {
+		$input          = '<iframe width="560" height="315" src="https://www.YouTube.cOm/embed/TcWPiHjIExA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>';
+		$expected       = '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/TcWPiHjIExA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>';
+
+		$this->assertSame( $expected, $this->youtube_filter->force_youtube_no_cookie_embed( $input ) );
+	}
+
+	public function test_it_passes_through_invalid_string_values(): void {
+		$this->assertSame( '', $this->youtube_filter->force_youtube_no_cookie_embed( '' ) );
+		$this->assertSame( 'test', $this->youtube_filter->force_youtube_no_cookie_embed( 'test' ) );
+		$this->assertSame( 'https://tri.be/youtube', $this->youtube_filter->force_youtube_no_cookie_embed( 'https://tri.be/youtube' ) );
+	}
+
+	public function test_it_replaces_youtube_embeds_within_blocks(): void {
+		add_filter(
+			'oembed_dataparse',
+			fn ( $html ) =>
+			$this->youtube_filter->force_youtube_no_cookie_embed( (string) $html ),
+			999,
+			1
+		);
+
+		$post_id = $this->factory()->post->create( [
+			'post_title'   => 'YouTube Embed',
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:paragraph -->
+<p>This is a test</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:embed {"url":"https://www.youtube.com/watch?v=TcWPiHjIExA","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=TcWPiHjIExA
+</div></figure>
+<!-- /wp:embed -->',
+		] );
+
+		$content = apply_filters( 'the_content', get_post( $post_id )->post_content );
+
+		$this->assertStringNotContainsString( 'youtube.com', $content );
+		$this->assertStringContainsString( 'https://www.youtube-nocookie.com/embed/TcWPiHjIExA?feature=oembed', $content );
+	}
+
+}


### PR DESCRIPTION
Using this official Google domain, no cookies will be set when the videos simply load on a page (but some will still be set when playing videos).

This only works on videos being rendered with WordPress's oEmbed processor.