### PR TITLE
[4.x]: SVG store for storing and displaying inline SVG markup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Install test dependencies
         run: composer -- test:install-plugins
 
+      - name: Run unit tests
+        run: composer test:unit
+
       - name: Run integration tests
         run: composer test:integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added: SVG storage system that parses SVGs on upload to capture their markup for quick access to display inline in components.
+- Added: The SVG store command to add or remove SVG markup to the database. Run `wp s1 help svg store` for details.
+- Added: Codeception unit testing suite utilizing Brain Monkey for mocking.
+- Changed: Base `Test_Case` class to allow developers to build a container with specific definers/subscribers for their specific test cases.
+- Added: More composer commands to run automated tests:
+  - `composer test:all` - run all test suites.
+  - `composer test:unit` - run unit tests.
+  - `compser test:integration` - run integration tests.
 
 ## 4.1.0 - 2022-10-03
 - Added: All YouTube oEmbeds will use youtube-nocookie.com, but can be disabled in your project with `define( 'TRIBE_ENABLE_YOUTUBE_NOCOOKIE_URI', false )` in your wp-config.php.

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,14 @@
             "@wpdownloader copy tests/.env-dist tests/.env"
         ],
         "test": "@php vendor/bin/codecept --config ./tests",
-        "test:integration": "@test run integration"
+        "test:integration": "@test run integration",
+        "test:unit": "@test run unit"
     },
     "require": {
         "php": ">=7.4",
+        "ext-dom": "*",
         "ext-json": "*",
+        "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-zlib": "*",
         "composer-plugin-api": "^1.0 || ^2.0",
@@ -44,6 +47,7 @@
     "require-dev": {
         "automattic/phpcs-neutron-standard": "^1.5",
         "automattic/vipwpcs": "^2.0",
+        "brain/monkey": "2.*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || ^0.7.0",
         "fakerphp/faker": "^1.20",
         "lucatume/wp-browser": "^3.1",
@@ -51,7 +55,9 @@
         "nette/utils": "^3.2 || ^4.0",
         "phpcompatibility/php-compatibility": "10.x-dev#c23e20c as 9.3.5",
         "phpcompatibility/phpcompatibility-wp": "^2.0",
+        "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan-mockery": "^1.1",
         "phpunit/phpunit": "^8.0 || ^9.0",
         "sirbrillig/phpcs-variable-analysis": "^2.0",
         "squizlabs/php_codesniffer": "^3.4.2",
@@ -99,7 +105,10 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tribe\\Libs\\": "tests/integration/Tribe/Libs",
+            "Tribe\\Libs\\": [
+                "tests/integration/Tribe/Libs",
+                "tests/unit/Tribe/Libs"
+            ],
             "Tribe\\Libs\\Dev\\Monorepo\\": "dev/monorepo/src",
             "Tribe\\Libs\\Tests\\": "tests/_support/Classes/",
             "Tribe\\Libs\\Tests\\Fixtures\\": "tests/_support/Fixtures/",
@@ -142,8 +151,10 @@
         "sort-packages": true,
         "vendor-dir": "vendor",
         "preferred-install": "dist",
+        "optimize-autoloader": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "lucatume/wp-browser": "^3.1",
         "nelexa/zip": "^4.0",
         "nette/utils": "^3.2 || ^4.0",
-        "phpcompatibility/php-compatibility": "10.x-dev#c23e20c as 9.3.5",
+        "phpcompatibility/php-compatibility": "10.x-dev#a726377 as 9.3.5",
         "phpcompatibility/phpcompatibility-wp": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,11 @@
         ],
         "test": "@php vendor/bin/codecept --config ./tests",
         "test:integration": "@test run integration",
-        "test:unit": "@test run unit"
+        "test:unit": "@test run unit",
+        "test:all": [
+          "@test:unit",
+          "@test:integration"
+        ]
     },
     "require": {
         "php": ">=7.4",

--- a/src/Media/CLI/Svg_Command.php
+++ b/src/Media/CLI/Svg_Command.php
@@ -48,9 +48,10 @@ class Svg_Command extends Command {
 				],
 			],
 			[
-				'type'     => self::FLAG,
-				'name'     => self::FLAG_YES,
-				'optional' => true,
+				'type'        => self::FLAG,
+				'name'        => self::FLAG_YES,
+				'description' => __( 'Skip all confirmations.', 'tribe' ),
+				'optional'    => true,
 			],
 		];
 	}

--- a/src/Media/CLI/Svg_Command.php
+++ b/src/Media/CLI/Svg_Command.php
@@ -2,11 +2,12 @@
 
 namespace Tribe\Libs\Media\CLI;
 
+use Throwable;
 use Tribe\Libs\CLI\Command;
-
 use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
 use WP_CLI;
 use WP_Query;
+
 use function WP_CLI\Utils\get_flag_value;
 
 class Svg_Command extends Command {
@@ -94,8 +95,13 @@ class Svg_Command extends Command {
 				continue;
 			}
 
-			if ( ! $this->svg_store->save( $file, $id ) ) {
-				WP_CLI::warning( sprintf( __( 'Error storing SVG markup for attachment ID: %d', 'tribe' ), $id ) );
+			try {
+				if ( ! $this->svg_store->save( $file, $id ) ) {
+					WP_CLI::warning( sprintf( __( 'Error storing SVG markup for attachment ID: %d', 'tribe' ), $id ) );
+				}
+			} catch ( Throwable $e ) {
+				WP_CLI::debug( $e->getMessage() . ': ' . $e->getTraceAsString() );
+				WP_CLI::warning( sprintf( __( 'An error occurred processing attachment ID "%d. Rerun the command with the --debug option', 'tribe' ), $id ) );
 			}
 		}
 

--- a/src/Media/CLI/Svg_Command.php
+++ b/src/Media/CLI/Svg_Command.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\CLI;
+
+use Tribe\Libs\CLI\Command;
+
+use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
+use WP_CLI;
+use WP_Query;
+use function WP_CLI\Utils\get_flag_value;
+
+class Svg_Command extends Command {
+
+	public const OPTION_TASK   = 'task';
+	public const OPTION_ADD    = 'add';
+	public const OPTION_REMOVE = 'remove';
+	public const FLAG_YES      = 'yes';
+
+	protected string $meta_key;
+	protected Svg_Store $svg_store;
+
+	public function __construct( string $meta_key, Svg_Store $svg_store ) {
+		parent::__construct();
+
+		$this->meta_key  = $meta_key;
+		$this->svg_store = $svg_store;
+	}
+
+	protected function command(): string {
+		return 'svg store';
+	}
+
+	protected function description(): string {
+		return __( 'Add or remove SVG markup storage to existing attachments', 'tribe' );
+	}
+
+	protected function arguments(): array {
+		return [
+			[
+				'type'        => self::OPTION,
+				'name'        => self::OPTION_TASK,
+				'optional'    => false,
+				'description' => __( 'Add or remove SVG markup meta to all SVG attachments in the database.', 'tribe' ),
+				'options'     => [
+					self::OPTION_ADD,
+					self::OPTION_REMOVE,
+				],
+			],
+			[
+				'type'     => self::FLAG,
+				'name'     => self::FLAG_YES,
+				'optional' => true,
+			],
+		];
+	}
+
+	public function run_command( $args, $assoc_args ) {
+		$task              = get_flag_value( $assoc_args, self::OPTION_TASK );
+		$skip_confirmation = get_flag_value( $assoc_args, self::FLAG_YES, false );
+
+		if ( $task === self::OPTION_ADD ) {
+			$this->add_markup( $skip_confirmation );
+		} else {
+			$this->remove_markup( $skip_confirmation );
+		}
+	}
+
+	protected function add_markup( bool $skip_confirmation ) {
+		$query = (new WP_Query( [
+			'post_type'      => 'attachment',
+			'post_mime_type' => 'image/svg+xml',
+			'post_status'    => 'inherit',
+			'posts_per_page' => - 1,
+			'fields'         => 'ids',
+		] ));
+
+		if ( ! $query->posts ) {
+			WP_CLI::warning( __( 'No SVGs found in the database.', 'tribe' ) );
+
+			return;
+		}
+
+		if ( ! $skip_confirmation ) {
+			WP_CLI::confirm( sprintf( __( 'This will add SVG markup meta for "%d" SVG attachment(s). Continue?', 'tribe' ), $query->post_count ) );
+		}
+
+		foreach ( $query->posts as $id ) {
+			WP_CLI::debug( sprintf( __( 'Adding SVG markup to attachment: %d', 'tribe' ), $id ) );
+
+			$file = get_attached_file( $id );
+
+			if ( ! $file ) {
+				WP_CLI::debug( sprintf( __( 'No attached file for attachment with ID: %d. Skipping...', 'tribe' ), $id ) );
+				continue;
+			}
+
+			if ( ! $this->svg_store->save( $file, $id ) ) {
+				WP_CLI::warning( sprintf( __( 'Error storing SVG markup for attachment ID: %d', 'tribe' ), $id ) );
+			}
+		}
+
+		WP_CLI::success( sprintf( __( 'Finished processing "%d" attachments', 'tribe' ), $query->post_count ) );
+	}
+
+	protected function remove_markup( bool $skip_confirmation ) {
+		global $wpdb;
+
+		if ( ! $skip_confirmation ) {
+			WP_CLI::confirm( sprintf( __( 'Delete all meta keys in the postmeta table with the key of "%s"?', 'tribe' ), $this->meta_key ) );
+		}
+
+		$count = $wpdb->delete( $wpdb->postmeta, [
+			'meta_key' => $this->meta_key,
+		], [
+			'%s',
+		] );
+
+		if ( $count === false ) {
+			WP_CLI::error( __( 'Deleting SVG markup from attachments failed.', 'tribe' ) );
+		} else {
+			WP_CLI::success( sprintf( __( 'Deleted "%d" records.', 'tribe' ), $count ) );
+		}
+	}
+
+}

--- a/src/Media/Media_Definer.php
+++ b/src/Media/Media_Definer.php
@@ -1,21 +1,31 @@
-<?php
-declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tribe\Libs\Media;
 
+use DI;
 use enshrined\svgSanitize\Sanitizer;
-use Psr\Container\ContainerInterface;
 use Tribe\Libs\Container\Definer_Interface;
+use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
+use Tribe\Libs\Media\Svg\Store\Stores\Svg_Meta_Store;
 
 class Media_Definer implements Definer_Interface {
+
+	public const SVG_INLINE_META_KEY = '_tribe_svg_source';
+
 	public function define(): array {
 		return [
-			Sanitizer::class => static function ( ContainerInterface $container ) {
+			Sanitizer::class      => static function () {
 				$sanitizer = new Sanitizer();
+				// This could cause potential issues with non UTF-8/UTF-16 SVGs.
+				$sanitizer->removeXMLTag( true );
 				$sanitizer->minify( true );
+				$sanitizer->setXMLOptions( 0 );
 
 				return $sanitizer;
 			},
+			Svg_Meta_Store::class => DI\autowire()
+				->constructorParameter( 'meta_key', self::SVG_INLINE_META_KEY ),
+			Svg_Store::class      => DI\get( Svg_Meta_Store::class ),
 		];
 	}
 

--- a/src/Media/Media_Definer.php
+++ b/src/Media/Media_Definer.php
@@ -3,6 +3,7 @@
 namespace Tribe\Libs\Media;
 
 use DI;
+use DOMDocument;
 use enshrined\svgSanitize\Sanitizer;
 use Tribe\Libs\Container\Definer_Interface;
 use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
@@ -14,10 +15,9 @@ class Media_Definer implements Definer_Interface {
 
 	public function define(): array {
 		return [
+			DOMDocument::class    => static fn() => new DOMDocument( '1.0' ),
 			Sanitizer::class      => static function () {
 				$sanitizer = new Sanitizer();
-				// This could cause potential issues with non UTF-8/UTF-16 SVGs.
-				$sanitizer->removeXMLTag( true );
 				$sanitizer->minify( true );
 				$sanitizer->setXMLOptions( 0 );
 

--- a/src/Media/Media_Definer.php
+++ b/src/Media/Media_Definer.php
@@ -17,7 +17,10 @@ class Media_Definer implements Definer_Interface {
 
 	public function define(): array {
 		return [
-			DOMDocument::class        => static fn() => new DOMDocument( '1.0' ),
+			// The post meta key for storing SVG markup.
+			self::SVG_INLINE_META_KEY => '_tribe_svg_markup',
+
+			DOMDocument::class        => static fn() => new DOMDocument(),
 			Sanitizer::class          => static function () {
 				$sanitizer = new Sanitizer();
 				$sanitizer->minify( true );
@@ -26,8 +29,6 @@ class Media_Definer implements Definer_Interface {
 				return $sanitizer;
 			},
 
-			// The post meta key for storing SVG markup.
-			self::SVG_INLINE_META_KEY => '_tribe_svg_markup',
 			Svg_Meta_Store::class     => DI\autowire()
 				->constructorParameter( 'meta_key', DI\get( self::SVG_INLINE_META_KEY ) ),
 			Svg_Store::class          => DI\get( Svg_Meta_Store::class ),

--- a/src/Media/Media_Definer.php
+++ b/src/Media/Media_Definer.php
@@ -5,27 +5,39 @@ namespace Tribe\Libs\Media;
 use DI;
 use DOMDocument;
 use enshrined\svgSanitize\Sanitizer;
+use Tribe\Libs\CLI\CLI_Definer;
 use Tribe\Libs\Container\Definer_Interface;
+use Tribe\Libs\Media\CLI\Svg_Command;
 use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
 use Tribe\Libs\Media\Svg\Store\Stores\Svg_Meta_Store;
 
 class Media_Definer implements Definer_Interface {
 
-	public const SVG_INLINE_META_KEY = '_tribe_svg_source';
+	public const SVG_INLINE_META_KEY = 'media.svg.store.meta_key';
 
 	public function define(): array {
 		return [
-			DOMDocument::class    => static fn() => new DOMDocument( '1.0' ),
-			Sanitizer::class      => static function () {
+			DOMDocument::class        => static fn() => new DOMDocument( '1.0' ),
+			Sanitizer::class          => static function () {
 				$sanitizer = new Sanitizer();
 				$sanitizer->minify( true );
 				$sanitizer->setXMLOptions( 0 );
 
 				return $sanitizer;
 			},
-			Svg_Meta_Store::class => DI\autowire()
-				->constructorParameter( 'meta_key', self::SVG_INLINE_META_KEY ),
-			Svg_Store::class      => DI\get( Svg_Meta_Store::class ),
+
+			// The post meta key for storing SVG markup.
+			self::SVG_INLINE_META_KEY => '_tribe_svg_markup',
+			Svg_Meta_Store::class     => DI\autowire()
+				->constructorParameter( 'meta_key', DI\get( self::SVG_INLINE_META_KEY ) ),
+			Svg_Store::class          => DI\get( Svg_Meta_Store::class ),
+
+			// CLI command to add/remove SVG markup from the database.
+			Svg_Command::class    => DI\autowire()
+				->constructorParameter( 'meta_key', DI\get( self::SVG_INLINE_META_KEY ) ),
+			CLI_Definer::COMMANDS => DI\add( [
+				DI\get( Svg_Command::class ),
+			] ),
 		];
 	}
 

--- a/src/Media/Media_Subscriber.php
+++ b/src/Media/Media_Subscriber.php
@@ -7,6 +7,7 @@ use Tribe\Libs\Media\Oembed\YouTube_Oembed_Filter;
 use Tribe\Libs\Media\Svg\Enable_Uploads;
 use Tribe\Libs\Media\Svg\Sanitize_Uploads;
 use Tribe\Libs\Media\Svg\Set_Attachment_Metadata;
+use Tribe\Libs\Media\Svg\Store\Svg_Store_Handler;
 
 class Media_Subscriber extends Abstract_Subscriber {
 
@@ -54,6 +55,24 @@ class Media_Subscriber extends Abstract_Subscriber {
 		add_filter( 'wp_generate_attachment_metadata', function ( $metadata, $attachment_id ) {
 			return $this->container->get( Set_Attachment_Metadata::class )->generate_metadata( $metadata, (int) $attachment_id );
 		}, 10, 2 );
+
+		$this->svg_inline_storage();
+	}
+
+	/**
+	 * Store SVG inline markup in post meta when an SVG is uploaded to the media library.
+	 *
+	 * @throws \Psr\Container\ContainerExceptionInterface
+	 * @throws \Psr\Container\NotFoundExceptionInterface
+	 */
+	private function svg_inline_storage(): void {
+		if ( defined( 'TRIBE_ENABLE_SVG_INLINE_STORAGE' ) && TRIBE_ENABLE_SVG_INLINE_STORAGE === false ) {
+			return;
+		}
+
+		add_filter( 'update_attached_file', function ( $file, $attachment_id ): string {
+			return $this->container->get( Svg_Store_Handler::class )->store( (string) $file, (int) $attachment_id );
+		}, 90, 2 );
 	}
 
 	private function disable_responsive_images(): void {

--- a/src/Media/README.md
+++ b/src/Media/README.md
@@ -28,7 +28,9 @@ define( 'DISABLE_WP_RESPONSIVE_IMAGES', false ); // disables the responsive imag
 
 When new SVGs are uploaded/modified, their markup is saved to post meta so future file reads aren't required to get the SVG markup.
 
-Reading file contents is slower than a database record and any projects using cloud based file systems (s3) won't need to make remote connections and will only slow down during the initial upload when the file is parsed.
+Reading file contents is slower than a database record and any projects using Cloud/Remote Based File Systems, such as s3 won't need to make remote connections and will only slow down during the initial upload where parsing and storage will take place.
+
+> **Tip:** SVG markup is only stored when an SVG attachment is uploaded to the media library. To store SVG attachment markup that was uploaded before this feature was active, run the CLI command: `wp s1 svg store --task=add`.
 
 ### Fetching stored SVG markup
 
@@ -67,3 +69,5 @@ With the following define, **newly uploaded SVGs** will no longer have their mar
 ```php
 define( 'TRIBE_ENABLE_SVG_INLINE_STORAGE', false );
 ```
+
+> **Tip:** run the CLI command `wp s1 svg store --task=remove` to delete all existing SVG markup meta keys.

--- a/src/Media/README.md
+++ b/src/Media/README.md
@@ -9,7 +9,7 @@ WordPress to use the full size version of GIF images.
 
 Disable this feature by setting a constant in your `wp-config.php` (by default, it is enabled).
 
-```
+```php
 define( 'FORCE_FULL_SIZE_GIFS', false ); // disables the full size GIF filter
 ```
 
@@ -20,6 +20,50 @@ so we disable its responsive image filters.
 
 Disable this feature by setting a constant in your `wp-config.php` (by default, it is enabled).
 
-```
+```php
 define( 'DISABLE_WP_RESPONSIVE_IMAGES', false ); // disables the responsive images disabler
+```
+
+## SVG Markup Storage
+
+When new SVGs are uploaded/modified, their markup is saved to post meta so future file reads aren't required to get the SVG markup.
+
+Reading file contents is slower than a database record and any projects using cloud based file systems (s3) won't need to make remote connections and will only slow down during the initial upload when the file is parsed.
+
+### Fetching stored SVG markup
+
+Simply auto-inject the `Svg_Store` interface into your controller, and fetch the markup via `$attachment_id`. 
+
+```php
+<?php declare(strict_types=1);
+
+namespace Tribe\Project\Controllers;
+
+use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store
+
+class My_Controller {
+    
+    protected Svg_Store $svg_store;
+    
+    public function __construct( Svg_Store $svg_store ) {
+        $this->svg_store = $svg_store;
+    }
+    
+    public function get_inline_logo(): string {
+        // Image/Attachment ID fetched from settings/featured image etc...
+        $image_id = 10;
+        
+        // Return the sanitized SVG markup.
+        return $this->svg_store->get( $image_id );
+    }
+    
+}
+```
+
+### Disable SVG storage system
+
+With the following define, **newly uploaded SVGs** will no longer have their markup stored in post meta. Existing SVG meta will still remain in the database.
+
+```php
+define( 'TRIBE_ENABLE_SVG_INLINE_STORAGE', false );
 ```

--- a/src/Media/Svg/Store/Contracts/Svg_Store.php
+++ b/src/Media/Svg/Store/Contracts/Svg_Store.php
@@ -17,10 +17,11 @@ interface Svg_Store {
 	/**
 	 * Fetch the sanitized markup of an SVG.
 	 *
-	 * @param int $attachment_id The attachment/post ID.
+	 * @param  int   $attachment_id  The attachment/post ID.
+	 * @param  bool  $remove_xml_tag Strip XML from SVG markup.
 	 *
 	 * @return string The sanitized markup.
 	 */
-	public function get( int $attachment_id ): string;
+	public function get( int $attachment_id, bool $remove_xml_tag = true ): string;
 
 }

--- a/src/Media/Svg/Store/Contracts/Svg_Store.php
+++ b/src/Media/Svg/Store/Contracts/Svg_Store.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store\Contracts;
+
+interface Svg_Store {
+
+	/**
+	 * Store the markup of an SVG.
+	 *
+	 * @param string $file          The server path to the file.
+	 * @param int    $attachment_id The attachment/post ID.
+	 *
+	 * @return bool Whether we were able to save.
+	 */
+	public function save( string $file, int $attachment_id ): bool;
+
+	/**
+	 * Fetch the sanitized markup of an SVG.
+	 *
+	 * @param int $attachment_id The attachment/post ID.
+	 *
+	 * @return string The sanitized markup.
+	 */
+	public function get( int $attachment_id ): string;
+
+}

--- a/src/Media/Svg/Store/Stores/Svg_Memory_Store.php
+++ b/src/Media/Svg/Store/Stores/Svg_Memory_Store.php
@@ -31,10 +31,12 @@ class Svg_Memory_Store implements Svg_Store {
 		return true;
 	}
 
-	public function get( int $attachment_id ): string {
+	public function get( int $attachment_id, bool $remove_xml_tag = true ): string {
 		$dirty = $this->items[ $attachment_id ] ?? '';
 
-		return $this->sanitizer->sanitize( $dirty );
+		$this->sanitizer->removeXMLTag( $remove_xml_tag );
+
+		return trim( $this->sanitizer->sanitize( $dirty ) );
 	}
 
 }

--- a/src/Media/Svg/Store/Stores/Svg_Memory_Store.php
+++ b/src/Media/Svg/Store/Stores/Svg_Memory_Store.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store\Stores;
+
+use enshrined\svgSanitize\Sanitizer;
+use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
+use Tribe\Libs\Media\Svg\Store\Svg_Parser_Factory;
+
+/**
+ * Stores SVG markup in memory for as long as the request lives.
+ */
+class Svg_Memory_Store implements Svg_Store {
+
+	protected Svg_Parser_Factory $parser_factory;
+	protected Sanitizer $sanitizer;
+	protected array $items = [];
+
+	public function __construct(
+		Svg_Parser_Factory $parser_factory,
+		Sanitizer $sanitizer,
+		array $items = []
+	) {
+		$this->items          = $items;
+		$this->sanitizer      = $sanitizer;
+		$this->parser_factory = $parser_factory;
+	}
+
+	public function save( string $file, int $attachment_id ): bool {
+		$this->items[ $attachment_id ] = (string) $this->parser_factory->make( $file );
+
+		return true;
+	}
+
+	public function get( int $attachment_id ): string {
+		$dirty = $this->items[ $attachment_id ] ?? '';
+
+		return $this->sanitizer->sanitize( $dirty );
+	}
+
+}

--- a/src/Media/Svg/Store/Stores/Svg_Meta_Store.php
+++ b/src/Media/Svg/Store/Stores/Svg_Meta_Store.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store\Stores;
+
+use enshrined\svgSanitize\Sanitizer;
+use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
+use Tribe\Libs\Media\Svg\Store\Svg_Parser_Factory;
+
+/**
+ * Stores SVG markup in WordPress attachment meta.
+ */
+class Svg_Meta_Store implements Svg_Store {
+
+	protected string $meta_key;
+	protected Svg_Parser_Factory $parser_factory;
+	protected Sanitizer $sanitizer;
+
+	public function __construct(
+		string $meta_key,
+		Svg_Parser_Factory $parser_factory,
+		Sanitizer $sanitizer
+	) {
+		$this->sanitizer      = $sanitizer;
+		$this->parser_factory = $parser_factory;
+		$this->meta_key       = $meta_key;
+	}
+
+	public function save( string $file, int $attachment_id ): bool {
+		$svg = (string) $this->parser_factory->make( $file );
+
+		delete_post_meta( $attachment_id, $this->meta_key, $svg );
+
+		return (bool) update_post_meta( $attachment_id, $this->meta_key, $svg );
+	}
+
+	public function get( int $attachment_id ): string {
+		$dirty = (string) get_post_meta( $attachment_id, $this->meta_key, true );
+
+		return $this->sanitizer->sanitize( $dirty );
+	}
+
+}

--- a/src/Media/Svg/Store/Stores/Svg_Meta_Store.php
+++ b/src/Media/Svg/Store/Stores/Svg_Meta_Store.php
@@ -33,10 +33,12 @@ class Svg_Meta_Store implements Svg_Store {
 		return (bool) update_post_meta( $attachment_id, $this->meta_key, $svg );
 	}
 
-	public function get( int $attachment_id ): string {
+	public function get( int $attachment_id, bool $remove_xml_tag = true ): string {
 		$dirty = (string) get_post_meta( $attachment_id, $this->meta_key, true );
 
-		return $this->sanitizer->sanitize( $dirty );
+		$this->sanitizer->removeXMLTag( $remove_xml_tag );
+
+		return trim( $this->sanitizer->sanitize( $dirty ) );
 	}
 
 }

--- a/src/Media/Svg/Store/Svg_Parser.php
+++ b/src/Media/Svg/Store/Svg_Parser.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store;
+
+use DOMDocument;
+use RuntimeException;
+use Stringable;
+
+class Svg_Parser implements Stringable {
+
+	protected string $svg;
+	protected DOMDocument $xml_document;
+
+	public function __construct( DOMDocument $xml_document ) {
+		$this->xml_document = $xml_document;
+	}
+
+	/**
+	 * Load an SVG from file.
+	 *
+	 * @param string $file_path The server path to the SVG file.
+	 */
+	public function load_file( string $file_path ): self {
+		if ( ! is_readable( $file_path ) ) {
+			throw new RuntimeException( sprintf( 'Unable to read file: %s', $file_path ) );
+		}
+
+		$svg = file_get_contents( $file_path );
+
+		if ( $svg === false ) {
+			throw new RuntimeException( sprintf( 'Unable to get contents of file: %s', $file_path ) );
+		}
+
+		if ( $this->is_gzipped( $svg ) ) {
+			$svg = gzdecode( $svg );
+
+			if ( $svg === false ) {
+				throw new RuntimeException( sprintf( 'Unable to gzip decode file: %s', $file_path ) );
+			}
+		}
+
+		$this->svg = $svg;
+
+		return $this;
+	}
+
+	/**
+	 * Load an SVG from XML markup.
+	 *
+	 * @param string $svg The SVG XML.
+	 */
+	public function load_string( string $svg ): self {
+		if ( $this->is_gzipped( $svg ) ) {
+			$decoded = gzdecode( $svg );
+
+			if ( $decoded === false ) {
+				throw new RuntimeException( sprintf( 'Unable to gzip decode SVG: %s', $svg ) );
+			}
+
+			$svg = $decoded;
+		}
+
+		$this->svg = $svg;
+
+		return $this;
+	}
+
+	/**
+	 * Convert the SVG to a DOMDocument object so it can
+	 * be manipulated.
+	 */
+	public function toDom(): ?DOMDocument {
+		$this->maybe_throw_exception();
+
+		$loaded = $this->xml_document->loadXML( $this->svg );
+
+		return $loaded ? $this->xml_document : null;
+	}
+
+	/**
+	 * @throws \RuntimeException
+	 */
+	protected function maybe_throw_exception(): void {
+		if ( ! isset( $this->svg ) ) {
+			throw new RuntimeException( sprintf( 'The $svg property is not set, did you run %s::parse_file() or %s::parse_string()?', self::class, self::class ) );
+		}
+	}
+
+	/**
+	 * Check if the contents are gzipped.
+	 *
+	 * @see http://www.gzip.org/zlib/rfc-gzip.html#member-format
+	 *
+	 * @param string $markup The SVG markup.
+	 */
+	protected function is_gzipped( string $markup ): bool {
+		$headers = "\x1f" . "\x8b" . "\x08";
+
+		if ( function_exists( 'mb_strpos' ) ) {
+			return 0 === mb_strpos( $markup, $headers );
+		}
+
+		return str_starts_with( $markup, $headers );
+	}
+
+	/**
+	 * Return the SVG XML markup.
+	 */
+	public function __toString(): string {
+		$this->maybe_throw_exception();
+
+		return $this->svg;
+	}
+
+}

--- a/src/Media/Svg/Store/Svg_Parser_Factory.php
+++ b/src/Media/Svg/Store/Svg_Parser_Factory.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store;
+
+use DI\FactoryInterface;
+
+class Svg_Parser_Factory {
+
+	protected FactoryInterface $container;
+
+	public function __construct( FactoryInterface $container ) {
+		$this->container = $container;
+	}
+
+	/**
+	 * Make a parser instance with the correct SVG property.
+	 *
+	 * @param string $file_or_xml The server path to the file, or SVG XML markup.
+	 *
+	 * @throws \DI\DependencyException
+	 * @throws \DI\NotFoundException
+	 */
+	public function make( string $file_or_xml ): Svg_Parser {
+		$xml    = simplexml_load_string( $file_or_xml, null, LIBXML_NOERROR );
+		$parser = $this->container->make( Svg_Parser::class );
+
+		return $xml ? $parser->load_string( $file_or_xml ) : $parser->load_file( $file_or_xml );
+	}
+
+}

--- a/src/Media/Svg/Store/Svg_Store_Handler.php
+++ b/src/Media/Svg/Store/Svg_Store_Handler.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store;
+
+use RuntimeException;
+use Tribe\Libs\Media\Svg\Store\Contracts\Svg_Store;
+
+class Svg_Store_Handler {
+
+	protected Svg_Store $svg_store;
+
+	public function __construct( Svg_Store $svg_store ) {
+		$this->svg_store = $svg_store;
+	}
+
+	/**
+	 * Store SVG markup for retrieval later.
+	 *
+	 * @filter update_attached_file
+	 *
+	 * @param string $file          The path to the attached file to update.
+	 * @param int    $attachment_id The attachment/post ID.
+	 *
+	 * @throws \RuntimeException
+	 */
+	public function store( string $file, int $attachment_id ): string {
+		$mime = get_post_mime_type( $attachment_id );
+
+		if ( $mime !== 'image/svg+xml' ) {
+			return $file;
+		}
+
+		if ( ! $this->svg_store->save( $file, $attachment_id ) ) {
+			throw new RuntimeException( sprintf( 'Unable to save SVG markup from %s to attachment ID: %d', $file, $attachment_id ) );
+		}
+
+		return $file;
+	}
+
+}

--- a/src/Media/composer.json
+++ b/src/Media/composer.json
@@ -10,6 +10,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.4",
+        "ext-dom": "*",
+        "ext-libxml": "*",
         "ext-zlib": "*",
         "ext-simplexml": "*",
         "enshrined/svg-sanitize": "^0.15",

--- a/src/Media/composer.json
+++ b/src/Media/composer.json
@@ -15,7 +15,8 @@
         "ext-zlib": "*",
         "ext-simplexml": "*",
         "enshrined/svg-sanitize": "^0.15",
-        "moderntribe/square1-container": "^4.2"
+        "moderntribe/square1-container": "^4.2",
+        "moderntribe/square1-cli": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,4 +6,6 @@
 2. Run `composer test:setup` to download and configure test dependencies.
 3. If appropriate, edit [.env](.env) to update environment variables to match your local environment.
 4. Create the `tribe_libs_test` database.
-5. Run `composer test:integration` to run tests.
+5. Run `composer test:unit` to run unit tests.
+6. Run `composer test:integration` to run integration tests.
+7. Run `composer -- test:integration --env multisite` to run multisite specific integration tests.

--- a/tests/_data/media/test.svg
+++ b/tests/_data/media/test.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="49"/><circle cx="50" cy="50" r="44" stroke="#FFF" stroke-width="5"/><path d="M71 27a7 7 0 0 1 7-7c7 0 9 14 7 21L69 89h-5L51 53 38 89h-5L12 30h12l15 45 10-28-6-17h12l15 45 8-24c2-12-8-18-7-25" fill="#FFF"/><path d="M11 29h18m9 0h22" stroke-width="3" stroke="#FFF" stroke-linecap="round"/></svg>

--- a/tests/_support/Classes/Test_Case.php
+++ b/tests/_support/Classes/Test_Case.php
@@ -3,6 +3,7 @@
 namespace Tribe\Libs\Tests;
 
 use Codeception\TestCase\WPTestCase;
+use DI\ContainerBuilder;
 use Faker\Factory;
 use Faker\Generator;
 
@@ -19,11 +20,51 @@ class Test_Case extends WPTestCase {
 
 	protected Generator $faker;
 
+	/**
+	 * The PHP-DI container.
+	 *
+	 * @var \DI\FactoryInterface|\Invoker\InvokerInterface|\Psr\Container\ContainerInterface|null
+	 */
+	protected $c = null;
+
 	protected function setUp(): void {
 		// @phpstan-ignore-next-line
 		parent::setUp();
 
 		$this->faker = Factory::create();
+	}
+
+	protected function tearDown(): void {
+		// @phpstan-ignore-next-line
+		parent::tearDown();
+
+		$this->c = null;
+	}
+
+	/**
+	 * Create a PHP-DI container similar to SquareOne, based on the specific
+	 * definers and subscribers required for your test.
+	 *
+	 * Overload the setUp() method in your test and call this method after.
+	 *
+	 * @param  array<class-string<\Tribe\Libs\Container\Definer_Interface>>    $definers
+	 * @param  array<class-string<\Tribe\Libs\Container\Abstract_Subscriber>>  $subscribers
+	 *
+	 * @throws \Exception
+	 */
+	protected function make_di_container( array $definers, array $subscribers = [] ): void {
+		$builder = new ContainerBuilder();
+		$builder->useAutowiring( true );
+		$builder->useAnnotations( false );
+		$builder->addDefinitions( ...array_map( static fn( $classname ) => (new $classname())->define(), $definers ) );
+
+		$this->c = $builder->build();
+
+		if ( $subscribers ) {
+			foreach ( $subscribers as $subscriber_class ) {
+				(new $subscriber_class( $this->c ))->register();
+			}
+		}
 	}
 
 }

--- a/tests/_support/Classes/Test_Case.php
+++ b/tests/_support/Classes/Test_Case.php
@@ -25,7 +25,7 @@ class Test_Case extends WPTestCase {
 		// @phpstan-ignore-next-line
 		parent::setUp();
 
-		$this->faker   = Factory::create();
+		$this->faker = Factory::create();
 
 		$this->init_builder();
 	}

--- a/tests/_support/Classes/Test_Case.php
+++ b/tests/_support/Classes/Test_Case.php
@@ -3,7 +3,6 @@
 namespace Tribe\Libs\Tests;
 
 use Codeception\TestCase\WPTestCase;
-use DI\ContainerBuilder;
 use Faker\Factory;
 use Faker\Generator;
 
@@ -18,20 +17,17 @@ use Faker\Generator;
  */
 class Test_Case extends WPTestCase {
 
-	protected Generator $faker;
+	use With_DI_Container;
 
-	/**
-	 * The PHP-DI container.
-	 *
-	 * @var \DI\FactoryInterface|\Invoker\InvokerInterface|\Psr\Container\ContainerInterface|null
-	 */
-	protected $c = null;
+	protected Generator $faker;
 
 	protected function setUp(): void {
 		// @phpstan-ignore-next-line
 		parent::setUp();
 
-		$this->faker = Factory::create();
+		$this->faker   = Factory::create();
+
+		$this->init_builder();
 	}
 
 	protected function tearDown(): void {
@@ -39,32 +35,6 @@ class Test_Case extends WPTestCase {
 		parent::tearDown();
 
 		$this->c = null;
-	}
-
-	/**
-	 * Create a PHP-DI container similar to SquareOne, based on the specific
-	 * definers and subscribers required for your test.
-	 *
-	 * Overload the setUp() method in your test and call this method after.
-	 *
-	 * @param  array<class-string<\Tribe\Libs\Container\Definer_Interface>>    $definers
-	 * @param  array<class-string<\Tribe\Libs\Container\Abstract_Subscriber>>  $subscribers
-	 *
-	 * @throws \Exception
-	 */
-	protected function make_di_container( array $definers, array $subscribers = [] ): void {
-		$builder = new ContainerBuilder();
-		$builder->useAutowiring( true );
-		$builder->useAnnotations( false );
-		$builder->addDefinitions( ...array_map( static fn( $classname ) => (new $classname())->define(), $definers ) );
-
-		$this->c = $builder->build();
-
-		if ( $subscribers ) {
-			foreach ( $subscribers as $subscriber_class ) {
-				(new $subscriber_class( $this->c ))->register();
-			}
-		}
 	}
 
 }

--- a/tests/_support/Classes/Unit.php
+++ b/tests/_support/Classes/Unit.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Tests;
+
+use Brain\Monkey;
+
+/**
+ * Extend this for your unit tests that contain Brain Monkey
+ * configuration out of the box.
+ *
+ * @link https://brain-wp.github.io/BrainMonkey/
+ */
+class Unit extends \Codeception\Test\Unit {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+}

--- a/tests/_support/Classes/Unit.php
+++ b/tests/_support/Classes/Unit.php
@@ -12,14 +12,20 @@ use Brain\Monkey;
  */
 class Unit extends \Codeception\Test\Unit {
 
+	use With_DI_Container;
+
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+
+		$this->init_builder();
 	}
 
 	protected function tearDown(): void {
 		Monkey\tearDown();
 		parent::tearDown();
+
+		$this->c = null;
 	}
 
 }

--- a/tests/_support/Classes/With_DI_Container.php
+++ b/tests/_support/Classes/With_DI_Container.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Tests;
+
+use DI\ContainerBuilder;
+
+/**
+ * Allow test suites to set up a PHP-DI container similar to SquareOne.
+ */
+trait With_DI_Container {
+
+	/**
+	 * The PHP-DI container.
+	 *
+	 * @var \DI\FactoryInterface|\Invoker\InvokerInterface|\Psr\Container\ContainerInterface|null
+	 */
+	protected $c = null;
+	protected ContainerBuilder $builder;
+
+	/**
+	 * Creates a PHP-DI container similar to SquareOne, passing the specific
+	 * definers and subscribers required for your use in your specific test.
+	 *
+	 * Overload the setUp() method in your test and call this method after.
+	 *
+	 * @param  array<class-string<\Tribe\Libs\Container\Definer_Interface>>    $definers
+	 * @param  array<class-string<\Tribe\Libs\Container\Abstract_Subscriber>>  $subscribers
+	 *
+	 * @throws \Exception
+	 */
+	protected function init_container( array $definers, array $subscribers = [] ): void {
+		$this->builder->addDefinitions( ...array_map( static fn( $classname ) => (new $classname())->define(), $definers ) );
+
+		$this->c = $this->builder->build();
+
+		if ( $subscribers ) {
+			foreach ( $subscribers as $subscriber_class ) {
+				(new $subscriber_class( $this->c ))->register();
+			}
+		}
+	}
+
+	private function init_builder(): void {
+		$builder = new ContainerBuilder();
+		$builder->useAutowiring( true );
+		$builder->useAnnotations( false );
+
+		$this->builder = $builder;
+	}
+
+}

--- a/tests/integration/Tribe/Libs/Media/Svg/Store/Stores/SvgMetaStoreTest.php
+++ b/tests/integration/Tribe/Libs/Media/Svg/Store/Stores/SvgMetaStoreTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store\Stores;
+
+use Tribe\Libs\Media\Media_Definer;
+use Tribe\Libs\Media\Media_Subscriber;
+use Tribe\Libs\Tests\Test_Case;
+
+final class SvgMetaStoreTest extends Test_Case {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->make_di_container( [
+			Media_Definer::class,
+		], [
+			Media_Subscriber::class,
+		] );
+	}
+
+	public function test_it_stores_and_retrieves_an_uploaded_svg(): void {
+		$file          = codecept_data_dir( 'media/test.svg' );
+		$attachment_id = $this->factory()->attachment->create( [
+			'file'           => $file,
+			'post_mime_type' => 'image/svg+xml',
+		] );
+
+		$store = $this->c->make( Svg_Meta_Store::class );
+
+		$this->assertTrue( $store->save( get_attached_file( $attachment_id ), $attachment_id ) );
+		$this->assertEquals( file_get_contents( $file ), $store->get( $attachment_id ) );
+	}
+
+}

--- a/tests/integration/Tribe/Libs/Media/Svg/Store/Stores/SvgMetaStoreTest.php
+++ b/tests/integration/Tribe/Libs/Media/Svg/Store/Stores/SvgMetaStoreTest.php
@@ -11,7 +11,7 @@ final class SvgMetaStoreTest extends Test_Case {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->make_di_container( [
+		$this->init_container( [
 			Media_Definer::class,
 		], [
 			Media_Subscriber::class,

--- a/tests/integration/Tribe/Libs/Media/Svg/Store/Stores/SvgMetaStoreTest.php
+++ b/tests/integration/Tribe/Libs/Media/Svg/Store/Stores/SvgMetaStoreTest.php
@@ -28,7 +28,20 @@ final class SvgMetaStoreTest extends Test_Case {
 		$store = $this->c->make( Svg_Meta_Store::class );
 
 		$this->assertTrue( $store->save( get_attached_file( $attachment_id ), $attachment_id ) );
-		$this->assertEquals( file_get_contents( $file ), $store->get( $attachment_id ) );
+		$this->assertStringEqualsFile( $file, $store->get( $attachment_id ) );
+	}
+
+	public function test_it_keeps_xml_tag_in_svg_markup(): void {
+		$file          = codecept_data_dir( 'media/test.svg' );
+		$attachment_id = $this->factory()->attachment->create( [
+			'file'           => $file,
+			'post_mime_type' => 'image/svg+xml',
+		] );
+
+		$store = $this->c->make( Svg_Meta_Store::class );
+
+		$this->assertTrue( $store->save( get_attached_file( $attachment_id ), $attachment_id ) );
+		$this->assertEquals( '<?xml version="1.0" encoding="UTF-8"?> ' . file_get_contents( $file ), $store->get( $attachment_id, false ) );
 	}
 
 }

--- a/tests/integration/_bootstrap.php
+++ b/tests/integration/_bootstrap.php
@@ -1,2 +1,2 @@
-<?php
+<?php declare(strict_types=1);
 // Here you can initialize variables that will be available to your tests

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,5 +1,3 @@
-includes:
-	- ../vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 5
 	paths:

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/Stores/SvgMemoryStoreTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/Stores/SvgMemoryStoreTest.php
@@ -32,7 +32,14 @@ final class SvgMemoryStoreTest extends Unit {
 		$id = 55;
 
 		$this->assertTrue( $this->store->save( $this->file, $id ) );
-		$this->assertEquals( file_get_contents( $this->file ), $this->store->get( $id ) );
+		$this->assertStringEqualsFile( $this->file, $this->store->get( $id ) );
+	}
+
+	public function test_it_saves_and_retrieves_an_svg_while_keeping_xml_tag(): void {
+		$id = 55;
+
+		$this->assertTrue( $this->store->save( $this->file, $id ) );
+		$this->assertEquals( '<?xml version="1.0" encoding="UTF-8"?> ' . file_get_contents( $this->file ), $this->store->get( $id, false ) );
 	}
 
 }

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/Stores/SvgMemoryStoreTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/Stores/SvgMemoryStoreTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store\Stores;
+
+use DI\ContainerBuilder;
+use enshrined\svgSanitize\Sanitizer;
+use Tribe\Libs\Media\Svg\Store\Svg_Parser_Factory;
+use Tribe\Libs\Tests\Unit;
+
+final class SvgMemoryStoreTest extends Unit {
+
+	private Svg_Memory_Store $store;
+	private string $file;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$sanitizer = new Sanitizer();
+		$sanitizer->removeXMLTag( true );
+		$sanitizer->minify( true );
+		$sanitizer->setXMLOptions( 0 );
+
+		$this->store = new Svg_Memory_Store(
+			new Svg_Parser_Factory( ( new ContainerBuilder() )->build() ),
+			$sanitizer
+		);
+
+		$this->file = codecept_data_dir( 'media/test.svg' );
+	}
+
+	public function test_it_saves_and_retrieves_an_svg(): void {
+		$id = 55;
+
+		$this->assertTrue( $this->store->save( $this->file, $id ) );
+		$this->assertEquals( file_get_contents( $this->file ), $this->store->get( $id ) );
+	}
+
+}

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/Stores/SvgMemoryStoreTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/Stores/SvgMemoryStoreTest.php
@@ -2,7 +2,7 @@
 
 namespace Tribe\Libs\Media\Svg\Store\Stores;
 
-use DI\ContainerBuilder;
+use DOMDocument;
 use enshrined\svgSanitize\Sanitizer;
 use Tribe\Libs\Media\Svg\Store\Svg_Parser_Factory;
 use Tribe\Libs\Tests\Unit;
@@ -16,12 +16,15 @@ final class SvgMemoryStoreTest extends Unit {
 		parent::setUp();
 
 		$sanitizer = new Sanitizer();
-		$sanitizer->removeXMLTag( true );
 		$sanitizer->minify( true );
 		$sanitizer->setXMLOptions( 0 );
 
+		$this->builder->addDefinitions( [
+			DOMDocument::class => new DOMDocument(),
+		] );
+
 		$this->store = new Svg_Memory_Store(
-			new Svg_Parser_Factory( ( new ContainerBuilder() )->build() ),
+			new Svg_Parser_Factory( $this->builder->build() ),
 			$sanitizer
 		);
 

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserFactoryTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Tribe\Libs\Media\Svg\Store;
 
-use DI\ContainerBuilder;
+use DOMDocument;
 use Tribe\Libs\Tests\Unit;
 
 final class SvgParserFactoryTest extends Unit {
@@ -12,9 +12,11 @@ final class SvgParserFactoryTest extends Unit {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->factory = new Svg_Parser_Factory(
-			( new ContainerBuilder() )->build()
-		);
+		$this->builder->addDefinitions( [
+			DOMDocument::class => new DOMDocument(),
+		] );
+
+		$this->factory = new Svg_Parser_Factory( $this->builder->build() );
 	}
 
 	public function test_it_makes_a_parser_from_file(): void {

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserFactoryTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserFactoryTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store;
+
+use DI\ContainerBuilder;
+use Tribe\Libs\Tests\Unit;
+
+final class SvgParserFactoryTest extends Unit {
+
+	private Svg_Parser_Factory $factory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new Svg_Parser_Factory(
+			( new ContainerBuilder() )->build()
+		);
+	}
+
+	public function test_it_makes_a_parser_from_file(): void {
+		$file = codecept_data_dir( 'media/test.svg' );
+
+		$parser = $this->factory->make( $file );
+
+		$this->assertEquals( file_get_contents( $file ), (string) $parser );
+	}
+
+	public function test_it_makes_a_parser_from_string(): void {
+		$svg = '<svg height="100" width="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" /></svg>';
+
+		$parser = $this->factory->make( $svg );
+
+		$this->assertEquals( $svg, (string) $parser );
+	}
+
+}

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserFactoryTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserFactoryTest.php
@@ -22,7 +22,7 @@ final class SvgParserFactoryTest extends Unit {
 
 		$parser = $this->factory->make( $file );
 
-		$this->assertEquals( file_get_contents( $file ), (string) $parser );
+		$this->assertStringEqualsFile( $file, (string) $parser );
 	}
 
 	public function test_it_makes_a_parser_from_string(): void {

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store;
+
+use DOMDocument;
+use Tribe\Libs\Tests\Unit;
+
+final class SvgParserTest extends Unit {
+
+	private Svg_Parser $parser;
+	private string $file;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->parser = new Svg_Parser( new DOMDocument() );
+		$this->file   = codecept_data_dir( 'media/test.svg' );
+	}
+
+	public function test_it_loads_svg_file(): void {
+		$this->parser->load_file( $this->file );
+
+		$this->assertEquals( file_get_contents( $this->file ), (string) $this->parser );
+	}
+
+	public function test_it_loads_svg_strings(): void {
+		$svg = file_get_contents( $this->file );
+
+		$this->parser->load_string( $svg );
+
+		$this->assertEquals( file_get_contents( $this->file ), (string) $this->parser );
+	}
+
+	public function test_gzipped_svg(): void {
+		$svg     = file_get_contents( $this->file );
+		$gzipped = gzencode( $svg );
+
+		$this->assertSame( 0, mb_strpos( $gzipped, "\x1f" . "\x8b" . "\x08" ) );
+
+		$this->parser->load_string( $gzipped );
+
+		$this->assertEquals( $svg, (string) $this->parser );
+	}
+
+}

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgParserTest.php
@@ -20,7 +20,7 @@ final class SvgParserTest extends Unit {
 	public function test_it_loads_svg_file(): void {
 		$this->parser->load_file( $this->file );
 
-		$this->assertEquals( file_get_contents( $this->file ), (string) $this->parser );
+		$this->assertStringEqualsFile( $this->file, (string) $this->parser );
 	}
 
 	public function test_it_loads_svg_strings(): void {
@@ -28,7 +28,7 @@ final class SvgParserTest extends Unit {
 
 		$this->parser->load_string( $svg );
 
-		$this->assertEquals( file_get_contents( $this->file ), (string) $this->parser );
+		$this->assertStringEqualsFile( $this->file, (string) $this->parser );
 	}
 
 	public function test_gzipped_svg(): void {

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgStoreHandlerTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgStoreHandlerTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Media\Svg\Store;
+
+use DI\ContainerBuilder;
+use enshrined\svgSanitize\Sanitizer;
+use Mockery;
+use RuntimeException;
+use Brain\Monkey\Functions;
+use Tribe\Libs\Media\Svg\Store\Stores\Svg_Memory_Store;
+use Tribe\Libs\Tests\Unit;
+
+final class SvgStoreHandlerTest extends Unit {
+
+	private Svg_Memory_Store $store;
+	protected Svg_Store_Handler $handler;
+	private string $file;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$sanitizer = new Sanitizer();
+		$sanitizer->removeXMLTag( true );
+		$sanitizer->minify( true );
+		$sanitizer->setXMLOptions( 0 );
+
+		$this->store = new Svg_Memory_Store(
+			new Svg_Parser_Factory( ( new ContainerBuilder() )->build() ),
+			$sanitizer
+		);
+
+		$this->file    = codecept_data_dir( 'media/test.svg' );
+		$this->handler = new Svg_Store_Handler( $this->store );
+	}
+
+	public function test_handler_allows_svg_store(): void {
+		$attachment_id = 1;
+
+		Functions\when( 'get_post_mime_type' )->justReturn( 'image/svg+xml' );
+
+		$file = $this->handler->store( $this->file, $attachment_id );
+
+		$this->assertSame( $file, $this->file );
+		$this->assertSame( $this->store->get( $attachment_id ), file_get_contents( $this->file ) );
+	}
+
+	public function test_handler_bypass_non_svg_files(): void {
+		$attachment_id = 2;
+
+		Functions\when( 'get_post_mime_type' )->justReturn( 'image/gif' );
+
+		$this->handler->store( codecept_data_dir( 'media/test.gif' ), $attachment_id );
+
+		$this->assertEmpty( $this->store->get( $attachment_id ) );
+	}
+
+	public function test_handler_throws_exception_when_store_fails_to_save_svg_markup(): void {
+		$this->expectException( RuntimeException::class );
+		$attachment_id = 3;
+
+		Functions\when( 'get_post_mime_type' )->justReturn( 'image/svg+xml' );
+
+		$store = Mockery::mock( Svg_Memory_Store::class );
+		$store->shouldReceive( 'save' )
+			  ->once()
+			  ->with( $this->file, $attachment_id )
+			  ->andReturnFalse();
+
+		$handler = new Svg_Store_Handler( $store );
+
+		$handler->store( $this->file, $attachment_id );
+	}
+
+}

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgStoreHandlerTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgStoreHandlerTest.php
@@ -41,7 +41,7 @@ final class SvgStoreHandlerTest extends Unit {
 		$file = $this->handler->store( $this->file, $attachment_id );
 
 		$this->assertSame( $file, $this->file );
-		$this->assertSame( $this->store->get( $attachment_id ), file_get_contents( $this->file ) );
+		$this->assertStringEqualsFile( $this->file, $this->store->get( $attachment_id ) );
 	}
 
 	public function test_handler_bypass_non_svg_files(): void {

--- a/tests/unit/Tribe/Libs/Media/Svg/Store/SvgStoreHandlerTest.php
+++ b/tests/unit/Tribe/Libs/Media/Svg/Store/SvgStoreHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Tribe\Libs\Media\Svg\Store;
 
-use DI\ContainerBuilder;
+use DOMDocument;
 use enshrined\svgSanitize\Sanitizer;
 use Mockery;
 use RuntimeException;
@@ -20,12 +20,15 @@ final class SvgStoreHandlerTest extends Unit {
 		parent::setUp();
 
 		$sanitizer = new Sanitizer();
-		$sanitizer->removeXMLTag( true );
 		$sanitizer->minify( true );
 		$sanitizer->setXMLOptions( 0 );
 
+		$this->builder->addDefinitions( [
+			DOMDocument::class => new DOMDocument(),
+		] );
+
 		$this->store = new Svg_Memory_Store(
-			new Svg_Parser_Factory( ( new ContainerBuilder() )->build() ),
+			new Svg_Parser_Factory( $this->builder->build() ),
 			$sanitizer
 		);
 


### PR DESCRIPTION
This introduces a system that will parse an SVG attachment only when uploaded and store that markup in the database to avoid any future file reads, which is especially important for projects that utilize any Cloud/Remote file systems like s3, Azure buckets etc...

If you can imagine an inline SVG logo on every page, and when uncached page loads occur, that would require a remote connections to the cloud storage to read those contents and would drastically increase page load time and CPU usage on the host.

Instead, the file is only parsed when required, sanitized and stored in the database and be easily fetched with an attachment ID.

See the updated [README.md](https://github.com/moderntribe/tribe-libs/blob/88aee7e50afc2c5968d13fea77335bdf15e741c1/src/Media/README.md#svg-markup-storage) in this PR for more details, including how to disable it and the CLI command to add or remove the meta for existing SVG attachments in the database.