### PR TITLE
Add Gallery_Collection.php for automatic ACF Gallery Field mapping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added: Gallery_Collection field model for automatic mapping of the ACF Gallery Field.
 
 ## 4.1.0 - 2022-10-03
 - Added: All YouTube oEmbeds will use youtube-nocookie.com, but can be disabled in your project with `define( 'TRIBE_ENABLE_YOUTUBE_NOCOOKIE_URI', false )` in your wp-config.php.

--- a/src/Field_Models/Collections/Gallery_Collection.php
+++ b/src/Field_Models/Collections/Gallery_Collection.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Field_Models\Collections;
+
+use Spatie\DataTransferObject\DataTransferObjectCollection;
+use Tribe\Libs\Field_Models\Models\Image;
+
+class Gallery_Collection extends DataTransferObjectCollection {
+
+	public static function create( array $attachments ): Gallery_Collection {
+		return new static( Image::arrayOf( $attachments ) );
+	}
+
+	public function current(): Image {
+		return parent::current();
+	}
+
+	public function offsetGet( $offset ): ?Image {
+		return parent::offsetGet( $offset );
+	}
+
+}

--- a/src/Field_Models/Collections/Gallery_Collection.php
+++ b/src/Field_Models/Collections/Gallery_Collection.php
@@ -11,7 +11,7 @@ class Gallery_Collection extends DataTransferObjectCollection {
 		return new static( Image::arrayOf( $attachments ) );
 	}
 
-	public function current(): Image {
+	public function current(): ?Image {
 		return parent::current();
 	}
 

--- a/src/Field_Models/Collections/Swatch_Collection.php
+++ b/src/Field_Models/Collections/Swatch_Collection.php
@@ -14,7 +14,7 @@ class Swatch_Collection extends DataTransferObjectCollection {
 		return new static( Swatch::arrayOf( $swatches ) );
 	}
 
-	public function current(): Swatch {
+	public function current(): ?Swatch {
 		return parent::current();
 	}
 

--- a/src/Field_Models/Collections/User_Collection.php
+++ b/src/Field_Models/Collections/User_Collection.php
@@ -11,7 +11,7 @@ class User_Collection extends DataTransferObjectCollection {
 		return new static( User::arrayOf( $users ) );
 	}
 
-	public function current(): User {
+	public function current(): ?User {
 		return parent::current();
 	}
 

--- a/tests/unit/Tribe/Libs/Field_Models/Collections/CollectionMethodOverridesTest.php
+++ b/tests/unit/Tribe/Libs/Field_Models/Collections/CollectionMethodOverridesTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Libs\Field_Models\Collections;
+
+use Tribe\Libs\Field_Models\Models\Image;
+use Tribe\Libs\Field_Models\Models\Swatch;
+use Tribe\Libs\Field_Models\Models\User;
+use Tribe\Libs\Tests\Unit;
+
+class CollectionMethodOverridesTest extends Unit {
+	public function test_user_collection_method_overrides(): void {
+		$empty_collection = User_Collection::create( [] );
+
+		$this->assertInstanceOf( User_Collection::class, $empty_collection );
+		$this->assertNull( $empty_collection->offsetGet( 0 ) );
+
+		$collection = User_Collection::create( [
+			[
+				'ID' => 1,
+			],
+		] );
+
+		$this->assertInstanceOf( User_Collection::class, $collection );
+		$this->assertInstanceOf( User::class, $collection->current() );
+		$this->assertInstanceOf( User::class, $collection->offsetGet( 0 ) );
+	}
+
+	public function test_swatch_collection_method_overrides(): void {
+		$empty_collection = Swatch_Collection::create( [] );
+
+		$this->assertInstanceOf( Swatch_Collection::class, $empty_collection );
+		$this->assertNull( $empty_collection->offsetGet( 0 ) );
+
+		$collection = Swatch_Collection::create( [
+			[
+				'name' => 'Test',
+			],
+		] );
+
+		$this->assertInstanceOf( Swatch_Collection::class, $collection );
+		$this->assertInstanceOf( Swatch::class, $collection->current() );
+		$this->assertInstanceOf( Swatch::class, $collection->offsetGet( 0 ) );
+	}
+
+	public function test_gallery_collection_method_overrides(): void {
+		$empty_collection = Gallery_Collection::create( [] );
+
+		$this->assertInstanceOf( Gallery_Collection::class, $empty_collection );
+		$this->assertNull( $empty_collection->offsetGet( 0 ) );
+
+		$collection = Gallery_Collection::create( [
+			[
+				'id' => 1,
+			],
+		] );
+
+		$this->assertInstanceOf( Gallery_Collection::class, $collection );
+		$this->assertInstanceOf( Image::class, $collection->current() );
+		$this->assertInstanceOf( Image::class, $collection->offsetGet( 0 ) );
+	}
+}

--- a/tests/unit/Tribe/Libs/Field_Models/Collections/CollectionMethodOverridesTest.php
+++ b/tests/unit/Tribe/Libs/Field_Models/Collections/CollectionMethodOverridesTest.php
@@ -13,6 +13,7 @@ class CollectionMethodOverridesTest extends Unit {
 
 		$this->assertInstanceOf( User_Collection::class, $empty_collection );
 		$this->assertNull( $empty_collection->offsetGet( 0 ) );
+		$this->assertNull( $empty_collection->current() );
 
 		$collection = User_Collection::create( [
 			[
@@ -30,6 +31,7 @@ class CollectionMethodOverridesTest extends Unit {
 
 		$this->assertInstanceOf( Swatch_Collection::class, $empty_collection );
 		$this->assertNull( $empty_collection->offsetGet( 0 ) );
+		$this->assertNull( $empty_collection->current() );
 
 		$collection = Swatch_Collection::create( [
 			[
@@ -47,6 +49,7 @@ class CollectionMethodOverridesTest extends Unit {
 
 		$this->assertInstanceOf( Gallery_Collection::class, $empty_collection );
 		$this->assertNull( $empty_collection->offsetGet( 0 ) );
+		$this->assertNull( $empty_collection->current() );
 
 		$collection = Gallery_Collection::create( [
 			[


### PR DESCRIPTION
e.g.

```php
$gallery = \Tribe\Libs\Field_Models\Collections\Gallery_Collection::create( (array) get_field( 'gallery' ) );

foreach ( $gallery as $image ) {
    echo $image->id;
    echo $image->url; 
    // etc...
}
```