### PR TITLE
Fix ACF_Settings docblock

### DIFF
--- a/src/ACF/ACF_Settings.php
+++ b/src/ACF/ACF_Settings.php
@@ -31,7 +31,7 @@ abstract class ACF_Settings extends Base_Settings {
 	 * Get setting value
 	 *
 	 * @param string $key
-	 * @param null   $default
+	 * @param mixed  $default
 	 *
 	 * @return mixed
 	 */


### PR DESCRIPTION
default is not always null

This resolves a lot of type problems in square-one.
