### PR TITLE
Update enshrined/svg-sanitize to secure version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Updated: `enshrined/svg-sanitize` to 0.22 for security patch.
+
 ## 4.2.1 - 2023-03-07
 
 - Fixed: Incorrect docblock types in ACF_Settings. (thanks @szepeviktor).

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-simplexml": "*",
         "ext-zlib": "*",
         "composer-plugin-api": "^1.0 || ^2.0",
-        "enshrined/svg-sanitize": "^0.15",
+        "enshrined/svg-sanitize": "^0.22",
         "filp/whoops": "^2.2@dev",
         "mhcg/monolog-wp-cli": "^2.0",
         "php-di/php-di": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "test:integration": "@test run integration",
         "test:unit": "@test run unit",
         "test:all": [
-          "@test:unit",
-          "@test:integration"
+            "@test:unit",
+            "@test:integration"
         ]
     },
     "require": {

--- a/src/Media/composer.json
+++ b/src/Media/composer.json
@@ -14,7 +14,7 @@
         "ext-libxml": "*",
         "ext-zlib": "*",
         "ext-simplexml": "*",
-        "enshrined/svg-sanitize": "^0.15",
+        "enshrined/svg-sanitize": "^0.22",
         "moderntribe/square1-container": "^4.3",
         "moderntribe/square1-cli": "^4.3"
     },


### PR DESCRIPTION
Bump the version of `enshrined/svg-sanitize` to a secure version [per Dependabot](https://github.com/moderntribe/tribe-libs/security/dependabot/13).