### PR TITLE
Trying to overcome the Deprecated warnings this version brings for PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "enshrined/svg-sanitize": "^0.22",
         "filp/whoops": "^2.2@dev",
         "mhcg/monolog-wp-cli": "^2.0",
-        "php-di/php-di": "^6.0",
+        "php-di/php-di": "7.1.1",
         "psr/log": "^1.1 || ^2.0",
         "spatie/data-transfer-object": "^2.8",
         "twig/twig": "^3.0"

--- a/src/Post_Type/Post_Object.php
+++ b/src/Post_Type/Post_Object.php
@@ -36,7 +36,7 @@ class Post_Object {
 	 *                                      If you're not sure what to do here, chances
 	 *                                      are you should be calling self::get_post().
 	 */
-	public function __construct( $post_id = 0, Meta_Map $meta = null ) {
+	public function __construct( $post_id = 0, ?Meta_Map $meta = null ) {
 		$this->post_id = $post_id;
 		if ( isset( $meta ) ) {
 			$this->meta = $meta;

--- a/src/Post_Type/Post_Type_Registration.php
+++ b/src/Post_Type/Post_Type_Registration.php
@@ -12,7 +12,7 @@ class Post_Type_Registration {
 	 * @param Post_Type_Config           $config
 	 * @param Meta_Box_Handler_Interface $meta_box_handler
 	 */
-	public static function register( Post_Type_Config $config, Meta_Box_Handler_Interface $meta_box_handler = null ) {
+	public static function register( Post_Type_Config $config, ?Meta_Box_Handler_Interface $meta_box_handler = null ) {
 		$callback         = self::build_registration_callback( $config, $meta_box_handler );
 
 		// do not register until init


### PR DESCRIPTION
I am seeing a lot of messages like this when using tribe-libs on PHP 8.4:
Deprecated: DI\autowire(): Implicitly marking parameter $className as nullable is deprecated
 Deprecated: Tribe\Libs\Post_Type\Post_Object::__construct(): Implicitly marking parameter $meta as nullable is deprecated, the explicit nullable type must be used instead